### PR TITLE
Fix #12: Remove =null of VideoProcessorEvent::outputImageBitmap.

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@
           </p>
           <dl class="idl" title="interface VideoProcessorEvent : VideoMonitorEvent">
             <dt>
-              attribute ImageBitmap? outputImageBitmap=null
+              attribute ImageBitmap? outputImageBitmap
             </dt>
             <dd>
               The output video frame comes to the corresponding


### PR DESCRIPTION
Fix #12.
The VideoProcessorEvent::outputImageBitmap property should not have a default value.
