### PR TITLE
Contiguous IDL and prose adaptation to match the contemporary style

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,16 @@
         "http://www.w3.org/TR/WebIDL-1/#common-BufferSource"><dfn>BufferSource</dfn></a></code>
         is defined in [[!WEBIDL]]
       </p>
+      <p>
+        The following concepts and interfaces are defined in [[!HTML]]:
+      </p>
+      <ul>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">
+          event handler IDL attribute</a></dfn>
+        </li>
+      </ul>
     </section>
     <section>
       <h2>
@@ -215,88 +225,104 @@
         <h2>
           <code>DedicatedWorkerGlobalScope</code> interface
         </h2>
-        <p>
-          By extending <code>DedicatedWorkerGlobalScope</code> object with a
-          event handler, <code>onvideoprocess</code>, it is enabled the
-          generating, processing, and analyzing of video data directly using
-          JavaScript in a Worker thread.
+        <p link-for="DedicatedWorkerGlobalScope">
+          To enable generating, processing, and analyzing of video data
+          directly using JavaScript in a worker, the
+          <a>DedicatedWorkerGlobalScope</a> interface is extended with a
+          <a>onvideoprocess</a> <a>event handler IDL attribute</a>. <a>Video
+          monitor events</a> and <a>video processing events</a> are dispatched
+          at the <a>DedicatedWorkerGlobalScope</a> object.
         </p>
-        <p>
-          The <code><a>DedicatedWorkerGlobalScope</a></code> is the "inside" of
-          a <code>Worker</code>. It must not exist if the interface's relevant
-          namespace object is not a
-          <code><a>DedicatedWorkerGlobalScope</a></code> object.
+        <pre class="idl">
+          partial interface DedicatedWorkerGlobalScope {
+                          attribute EventHandler onvideoprocess;
+          };
+        </pre>
+        <p dfn-for="DedicatedWorkerGlobalScope">
+          The <dfn><code>onvideoprocess</code></dfn> is an <a>event handler IDL
+          attribute</a> for the <dfn><code>videoprocess</code></dfn> event
+          type.
         </p>
-        <dl class="idl" title="partial interface DedicatedWorkerGlobalScope">
-          <dt>
-            attribute EventHandler onvideoprocess
-          </dt>
-          <dd>
-            <p>
-              A property used to set the EventHandler (described in [[!HTML]])
-              for the <a><code>VideoMonitorEvent</code></a>/
-              <a><code>VideoProcessorEvent</code></a> that is dispatched to
-              <code><a>DedicatedWorkerGlobalScope</a></code> to process video
-              while the associated <code><a>MediaStreamTrack</a></code> are
-              connected. When a new input video frame is sent to corresponding
-              <code>MediaStreamTrack</code>, User Agent will create a
-              <code><a>VideoProcessEventThe</a></code> and dispatch it. Then
-              the event handler, of type <code><a>videoprocess</a></code>, is
-              executed .
-            </p>
-          </dd>
-        </dl>
       </section>
       <section>
         <h2>
           <code id="event-videomonitorevent">VideoMonitorEvent</code> interface
         </h2>
         <p>
-          This is an <code>Event</code> object which is dispatched to
-          <a><code>DedicatedWorkerGlobalScope</code></a> objects to perform
-          processing.
+          <dfn>Video monitor events</dfn> use the <a>VideoMonitorEvent</a>
+          interface for their <a>videoprocess</a> events:
         </p>
-        <p>
-          When the <code>MediaStreamTrack</code> comes a new video frame data,
-          the User Agent will dispatch a <code><a>VideoMonitorEvent</a></code>
-          to the associated Workers when the association is connected by
-          <code>addVideoMonitor</code>. The event handlers of those Workers
-          process video from the input by accessing the video data from the
-          <code>inputImageBitmap</code> attribute in the
-          <code>VideoMonitorEvent</code>.
-        </p>
-        <p>
-          Ideally the <code>MediaStreamTrack</code> should dispatch each video
-          frame through <code><a>VideoMonitorEvent</a></code>. But sometimes
-          the worker thread could not process the frame in time. So the
-          implementation could skip the frame to avoid high memory footprint.
-          In such case, we might not be able to process every frame in a real
-          time <code>MediaStream</code>.
-        </p>
-        <dl class="idl" title=
-        "[Exposed=Worker] interface VideoMonitorEvent : Event">
-          <dt>
-            readonly attribute DOMString trackId
-          </dt>
-          <dd>
-            The <code>MediaStreamTrack.id</code> of corresponding
-            <code>MediaStreamTrack</code>.
-          </dd>
-          <dt>
-            readonly attribute double playbackTime
-          </dt>
-          <dd>
-            The elapsed time of the <code>MediaStreamTrack</code> from the
-            <code>MediaStream</code> starting.
-          </dd>
-          <dt>
-            readonly attribute ImageBitmap inputImageBitmap
-          </dt>
-          <dd>
-            The input video frame comes from the corresponding
-            <code>MediaStreamTrack</code>.
-          </dd>
-        </dl>
+        <pre class="idl">
+          [Constructor(DOMString type, optional VideoMonitorEventInit videoMonitorEventInitDict), Exposed=Worker]
+          interface VideoMonitorEvent : Event {
+              readonly    attribute DOMString   trackId;
+              readonly    attribute double      playbackTime;
+              readonly    attribute ImageBitmap inputImageBitmap;
+          };
+
+          dictionary VideoMonitorEventInit : EventInit {
+            DOMString   trackId;
+            double      playbackTime;
+            ImageBitmap inputImageBitmap;
+          };
+        </pre>
+        <div dfn-for="VideoMonitorEvent">
+          <p>
+            The <dfn>trackId</dfn> attribute must return the value it was
+            initialized to. When the object is created, this attribute must be
+            initialized to the empty string. It represents the identifier that
+            is shared with the <a>video worker</a> and its <a>video worker
+            source</a>.
+          </p>
+          <p>
+            <!-- TODO: is this current stream position? -->
+             The <dfn>playbackTime</dfn> attribute must return the value it was
+            initialized to. When the object is created, this attribute must be
+            initialized to zero. It represents the current stream position, in
+            seconds.
+          </p>
+          <p>
+            The <dfn>inputImageBitmap</dfn> attribute must return the value it
+            was initialized to. When the object is created, this attribute must
+            be initialized to null. It represents the <a>ImageBitmap</a> object
+            whose bitmap data is provided by the <a>video worker source</a>.
+          </p>
+          <p>
+            A worker is said to be a <dfn>video worker</dfn> if it has a
+            <a>video worker source</a>.
+          </p>
+          <p>
+            A <a>MediaStreamTrack</a> object is said to be a <dfn>video worker
+            source</dfn> for a worker <var>w</var>, if its
+            <code>addVideoMonitor()</code> method has been invoked with
+            <var>w</var> as an argument.
+          </p>
+          <p>
+            When a user agent is required to <dfn>fire a video monitor
+            event</dfn>, it must run the following steps:
+          </p>
+        </div>
+        <ol link-for="VideoMonitorEvent">
+          <li>Create a <a>VideoMonitorEvent</a>, initialize it to have a name
+          <a>videoprocess</a>, to not bubble, to not be cancelable.
+          </li>
+          <li>Initialize the <a>trackId</a> attribute to the value of the
+          <code>id</code> attribute of the <a>video worker source</a>.
+          </li><!-- TODO -->
+          <li>Initialize the <a>playbackTime</a> attribute to the value of the
+          <code>currentTime</code> attribute of the <a>MediaStream</a> that
+          contains the <a>video worker source</a>.
+          </li>
+          <li>Initialize the <a>inputImageBitmap</a> attribute to the bitmap
+          data of the <a>video worker source</a>'s video frame at the current
+          stream position at <a>playbackTime</a>.
+          </li>
+          <li>Dispatch the newly created <a>VideoMonitorEvent</a> object at the
+          <a>DedicatedWorkerGlobalScope</a> of the <a title=
+          "video worker">video workers</a> that share the same <a>video worker
+          source</a>.
+          </li>
+        </ol>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -239,42 +239,45 @@
         Terminology
       </h2>
       <p>
-        A worker is said to be a <dfn>video worker</dfn> if it has a <a>video
-        worker source</a>.
+        A <dfn>video worker</dfn> takes an <a>input frame</a> from an
+        <dfn>input media stream track</dfn> and processes an <a>output
+        frame</a> that acts as the <a>source</a> for the <a>output media stream
+        track</a>.
       </p>
       <p>
-        There are two kinds of <dfn data-lt="video worker source">video worker
-        sources</dfn>:
+        An <dfn>input frame</dfn> for a worker <var>w</var> is an
+        <a>ImageBitmap</a> object representing a frame sourced from the
+        <a>MediaStreamTrack</a> object whose <code>addVideoMonitor()</code> or
+        <code>addVideoProcessor()</code> method has been invoked with
+        <var>w</var> as an argument. This association is cleared if
+        <code>removeVideoMonitor()</code> or
+        <code>removeVideoProcessor()</code> method is invoked with <var>w</var>
+        as an argument.
       </p>
-      <dl>
-        <dt>
-          <dfn>Video monitor source</dfn>
-        </dt>
-        <dd>
-          A <a>MediaStreamTrack</a> object is said to be a <a>video monitor
-          source</a> for a worker <var>w</var>, if its
-          <code>addVideoMonitor()</code> method has been invoked with
-          <var>w</var> as an argument. This association is cleared if
-          <code>removeVideoMonitor()</code> method is invoked with <var>w</var>
-          as an argument.
-        </dd>
-        <dt>
-          <dfn>Video processor source</dfn>
-        </dt>
-        <dd>
-          A <a>MediaStreamTrack</a> object is said to be a <a>video processor
-          source</a> for a worker <var>w</var>, if its
-          <code>addVideoProcessor()</code> method has been invoked with
-          <var>w</var> as an argument. This association is cleared if
-          <code>removeVideoProcessor()</code> method is invoked with
-          <var>w</var> as an argument.
-        </dd>
-      </dl>
+      <p link-for="VideoProcessorEvent">
+        The <dfn>output frame</dfn> is represented by the <a>ImageBitmap</a>
+        object assigned to the <a>outputImageBitmap</a> attribute of the
+        <a>VideoProcessorEvent</a>.
+      </p>
+      <p link-for="VideoProcessorEvent">
+        The <dfn>output media stream track</dfn> for a worker <var>w</var> is a
+        <a>MediaStreamTrack</a> object returned by the invocation of the
+        <code>addVideoProcessor()</code> method on <var>w</var>.
+      </p>
       <p>
         There are two kinds of <dfn data-lt="video worker event">video worker
-        events</dfn>: <a data-lt="video monitor event">video monitor events</a>
-        and <a data-lt="video processor event">video processor events</a>.
+        events</dfn>:
       </p>
+      <ul>
+        <li>
+          <a data-lt="video monitor event">Video monitor events</a> represent
+          the <a>input frame</a> only.
+        </li>
+        <li>
+          <a data-lt="video processor event">Video processor events</a>
+          represent the <a>input frame</a> and <a>output frame</a>.
+        </li>
+      </ul>
     </section>
     <section>
       <h2>
@@ -289,7 +292,8 @@
           directly using JavaScript in a worker, the
           <a>DedicatedWorkerGlobalScope</a> interface is extended with an
           <a>onvideomonitor</a> and <a>onvideoprocess</a> <a>event handler IDL
-          attribute</a>. <a>Video monitor events</a> and <a>video processor
+          attribute</a>. <a data-lt="video monitor event">Video monitor
+          events</a> and <a data-lt="video processor event">video processor
           events</a> are dispatched at the <a>DedicatedWorkerGlobalScope</a>
           object.
         </p>
@@ -359,23 +363,23 @@
             </li>
             <li link-for="VideoMonitorEvent">Initialize the <a>trackId</a>
             attribute to the value of the <code>id</code> attribute of the <a>
-              video worker source</a>.
+              input media stream track</a>.
             </li><!-- TODO -->
             <li link-for="VideoMonitorEvent">Initialize the <a>playbackTime</a>
             attribute to the value of the <code>currentTime</code> attribute of
-            the <a>MediaStream</a> that contains the <a>video worker
-            source</a>.
+            the <a>MediaStream</a> that contains the <a>input media stream
+            track</a>.
             </li>
             <li link-for="VideoMonitorEvent">Initialize the
             <a>inputImageBitmap</a> attribute to the bitmap data of the
-            <a>video worker source</a>'s video frame at the current stream
+            <a>input media stream track</a>'s video frame at the current stream
             position at <a>playbackTime</a>.
             </li>
             <li>
               <!-- TODO: clarify the definition of targets -->
               Let <var>associated video workers</var> be the list of
               <a data-lt="video worker">video workers</a> that share the same
-              <a>video worker source</a>.
+              <a>input media stream track</a>.
             </li>
             <li>If <var>e</var> is <a>videomonitor</a>, dispatch the newly
             created <a>VideoMonitorEvent</a> object at each <var>target</var>.
@@ -392,9 +396,11 @@
         <h2>
           <code id="event-videomonitorevent">VideoMonitorEvent</code> interface
         </h2>
-        <p>
-          <dfn>Video monitor events</dfn> use the <a>VideoMonitorEvent</a>
-          interface for their <a>videomonitor</a> events:
+        <p link-for="VideoMonitorEvent">
+          The <dfn>video monitor event</dfn> contains an <a>input frame</a> and
+          its metadata originating from the <a>input media stream track</a>. It
+          uses the <a>VideoMonitorEvent</a> interface for its
+          <a>videomonitor</a> events:
         </p>
         <pre class="idl">
           [Constructor(DOMString type, optional VideoMonitorEventInit videoMonitorEventInitDict), Exposed=Worker]
@@ -414,8 +420,8 @@
             The <dfn>trackId</dfn> attribute must return the value it was
             initialized to. When the object is created, this attribute must be
             initialized to the empty string. It represents the identifier that
-            is shared with the <a>video worker</a> and its <a>video worker
-            source</a>.
+            is shared with the <a>video worker</a> and its <a>input media
+            stream track</a>.
           </p>
           <p>
             <!-- TODO: is this current stream position? -->
@@ -428,7 +434,8 @@
             The <dfn>inputImageBitmap</dfn> attribute must return the value it
             was initialized to. When the object is created, this attribute must
             be initialized to null. It represents the <a>ImageBitmap</a> object
-            whose bitmap data is provided by the <a>video monitor source</a>.
+            whose bitmap data is provided by the <a>input media stream
+            track</a>.
           </p>
         </div>
         <p>
@@ -443,8 +450,11 @@
           interface
         </h2>
         <p link-for="VideoProcessorEvent">
-          <dfn>Video processor events</dfn> use the <a>VideoProcessorEvent</a>
-          interface for their <a>videoprocess</a> events:
+          The <dfn>video processor event</dfn> inherits from the <a>video
+          monitor event</a>, and in addition provides means to programmatically
+          construct an <a>output frame</a> for the <a>output media stream
+          track</a>. It uses the <a>VideoProcessorEvent</a> interface for its
+          <a>videoprocess</a> events:
         </p>
         <pre class="idl">
           [Constructor(DOMString type, optional VideoProcessorEventInit videoProcessorEventInitDict),

--- a/index.html
+++ b/index.html
@@ -224,6 +224,39 @@
     </section>
     <section>
       <h2>
+        Terminology
+      </h2>
+      <p>
+        A worker is said to be a <dfn>video worker</dfn> if it has a <a>video
+        worker source</a>.
+      </p>
+      <p>
+        There are two kinds of <dfn title="video worker source">video worker
+        sources</dfn>:
+      </p>
+      <dl>
+        <dt>
+          <dfn>Video monitor source</dfn>
+        </dt>
+        <dd>
+          A <a>MediaStreamTrack</a> object is said to be a <a>video monitor
+          source</a> for a worker <var>w</var>, if its
+          <code>addVideoMonitor()</code> method has been invoked with
+          <var>w</var> as an argument.
+        </dd>
+        <dt>
+          <dfn>Video processor source</dfn>
+        </dt>
+        <dd>
+          A <a>MediaStreamTrack</a> object is said to be a <a>video processor
+          source</a> for a worker <var>w</var>, if its
+          <code>addVideoProcessor()</code> method has been invoked with
+          <var>w</var> as an argument.
+        </dd>
+      </dl>
+    </section>
+    <section>
+      <h2>
         Extensions
       </h2>
       <section>
@@ -235,7 +268,7 @@
           directly using JavaScript in a worker, the
           <a>DedicatedWorkerGlobalScope</a> interface is extended with a
           <a>onvideoprocess</a> <a>event handler IDL attribute</a>. <a>Video
-          monitor events</a> and <a>video processing events</a> are dispatched
+          monitor events</a> and <a>video processor events</a> are dispatched
           at the <a>DedicatedWorkerGlobalScope</a> object.
         </p>
         <pre class="idl">
@@ -289,17 +322,7 @@
             The <dfn>inputImageBitmap</dfn> attribute must return the value it
             was initialized to. When the object is created, this attribute must
             be initialized to null. It represents the <a>ImageBitmap</a> object
-            whose bitmap data is provided by the <a>video worker source</a>.
-          </p>
-          <p>
-            A worker is said to be a <dfn>video worker</dfn> if it has a
-            <a>video worker source</a>.
-          </p>
-          <p>
-            A <a>MediaStreamTrack</a> object is said to be a <dfn>video worker
-            source</dfn> for a worker <var>w</var>, if its
-            <code>addVideoMonitor()</code> method has been invoked with
-            <var>w</var> as an argument.
+            whose bitmap data is provided by the <a>video monitor source</a>.
           </p>
           <p>
             When a user agent is required to <dfn>fire a video worker
@@ -307,19 +330,18 @@
           </p>
         </div>
         <ol>
-          <li>
           <li>Create a <a>VideoMonitorEvent</a>, initialize it to have a name
           <a>videoprocess</a>, to not bubble, to not be cancelable.
           </li>
           <li>Initialize the <a>trackId</a> attribute to the value of the
-          <code>id</code> attribute of the <a>video worker source</a>.
+          <code>id</code> attribute of the <a>video monitor source</a>.
           </li><!-- TODO -->
           <li>Initialize the <a>playbackTime</a> attribute to the value of the
           <code>currentTime</code> attribute of the <a>MediaStream</a> that
-          contains the <a>video worker source</a>.
+          contains the <a>video monitor source</a>.
           </li>
           <li>Initialize the <a>inputImageBitmap</a> attribute to the bitmap
-          data of the <a>video worker source</a>'s video frame at the current
+          data of the <a>video monitor source</a>'s video frame at the current
           stream position at <a>playbackTime</a>.
           </li>
           <li>Dispatch the newly created <a>VideoMonitorEvent</a> object at the

--- a/index.html
+++ b/index.html
@@ -463,7 +463,7 @@
                           attribute ImageBitmap? outputImageBitmap;
           };
 
-          dictionary VideoProcessorEventInit : EventInit {
+          dictionary VideoProcessorEventInit : VideoMonitorEventInit {
               required ImageBitmap? outputImageBitmap;
           };
         </pre>

--- a/index.html
+++ b/index.html
@@ -249,30 +249,57 @@
         Terminology
       </h2>
       <p>
-        A <dfn>video worker</dfn> captures an <a>input frame</a> from an
-        <dfn>input media stream track</dfn> and processes the provided
-        <a>output frame</a> for use as the <a>source</a> for the <a>output
-        media stream track</a>.
+        There are two kinds of <dfn data-lt="video worker">video workers</dfn>;
+        <a data-lt="monitoring video worker">monitoring video workers</a>, and
+        <a data-lt="processing video worker">processing video workers</a>:
       </p>
-      <p>
-        An <dfn>input frame</dfn> for a worker <var>w</var> is an
+      <dl>
+        <dt>
+          <a>Monitoring video worker</a>
+        </dt>
+        <dd>
+          Captures an <a>input frame</a> from an <a>input media stream
+          track</a>. A <a>video worker</a> is said to be a <dfn>monitoring
+          video worker</dfn>, if the <a>video worker</a> is associated with an
+          <a>input media stream track</a>. <a data-lt=
+          "video monitor event">Video monitor events</a> are dispatched at a
+          <a>monitoring video worker</a>.
+        </dd>
+        <dt>
+          <a>Processing video worker</a>
+        </dt>
+        <dd>
+          Similarly captures an <a>input frame</a> from an <a>input media
+          stream track</a>, and in addition, processes the provided <a>output
+          frame</a> for use as the <a>source</a> for the <a>output media stream
+          track</a>. A <a>video worker</a> is said to be a <dfn>processing
+          video worker</dfn>, if the <a>video worker</a> is associated with
+          both an <a>input media stream track</a> and an <a>output media stream
+          track</a>. <a data-lt="video processor event">Video processor
+          events</a> are dispatched at a <a>processing video worker</a>.
+        </dd>
+      </dl>
+      <p link-for="MediaStreamTrack">
+        An <dfn>input frame</dfn> for a <a>video worker</a> <var>w</var> is an
         <a>ImageBitmap</a> object representing a frame sourced from the
-        <a>MediaStreamTrack</a> object whose <code>addVideoMonitor()</code> or
-        <code>addVideoProcessor()</code> method has been invoked with
-        <var>w</var> as an argument. This association is cleared if
-        <code>removeVideoMonitor()</code> or
-        <code>removeVideoProcessor()</code> method is invoked with <var>w</var>
-        as an argument.
+        <a>input media stream track</a> associated with <var>w</var>.
       </p>
       <p link-for="VideoProcessorEvent">
-        The <dfn>output frame</dfn> is represented by the <a>ImageBitmap</a>
-        object assigned to the <a>outputImageBitmap</a> attribute of the
-        <a>VideoProcessorEvent</a>.
+        An <dfn>output frame</dfn> for a <a>video worker</a> <var>w</var> is an
+        <a>ImageBitmap</a> object assigned to the <a>outputImageBitmap</a>
+        attribute of the <a>VideoProcessorEvent</a> dispatched at <var>w</var>.
       </p>
-      <p link-for="VideoProcessorEvent">
-        The <dfn>output media stream track</dfn> for a worker <var>w</var> is a
-        <a>MediaStreamTrack</a> object returned by the invocation of the
-        <code>addVideoProcessor()</code> method on <var>w</var>.
+      <p link-for="MediaStreamTrack">
+        The <dfn>input media stream track</dfn> for a <a>video worker</a>
+        <var>w</var> is a <a>MediaStreamTrack</a> object passed as the first
+        argument to the <code><a>addVideoMonitor</a>()</code> or
+        <code><a>addVideoProcessor</a>()</code> method on <var>w</var>.
+      </p>
+      <p link-for="MediaStreamTrack">
+        The <dfn>output media stream track</dfn> for a <a>video worker</a>
+        <var>w</var> is a <a>MediaStreamTrack</a> object returned by the
+        invocation of the <code><a>addVideoProcessor</a>()</code> method on
+        <var>w</var>.
       </p>
       <p>
         There are two kinds of <dfn data-lt="video worker event">video worker
@@ -284,9 +311,8 @@
         </dt>
         <dd>
           These events are represented by <a>VideoMonitorEvent</a> objects that
-          are dispatched at <dfn>video worker monitor</dfn> and provide read
-          access to <a>input frame</a> data represented by an
-          <a>ImageBitmap</a> object.
+          are dispatched at a <a>monitoring video worker</a> and provide read
+          access to <a>input frame</a> data.
         </dd>
       </dl>
       <dl>
@@ -295,10 +321,9 @@
         </dt>
         <dd>
           These events are represented by <a>VideoProcessorEvent</a> objects
-          that are dispatched at <dfn>video worker processor</dfn> and provide
+          that are dispatched at a <a>processing video worker</a> and provide
           read access to <a>input frame</a> data and write access to <a>output
-          frame</a> data represented by <a>ImageBitmap</a> objects
-          respectively.
+          frame</a> data.
         </dd>
       </dl>
     </section>
@@ -503,9 +528,9 @@
           <li>Let <var>output bitmap</var> be the <a>ImageBitmap</a> object
           assigned to the <a>outputImageBitmap</a> attribute.
           </li>
-          <li>Let <var>output media stream track</var> be the
-          <a>MediaStreamTrack</a> returned by the
-          <code>addVideoProcessor()</code> method.
+          <li link-for="MediaStreamTrack">Let <var>output media stream
+          track</var> be the <a>MediaStreamTrack</a> returned by the <code><a>
+            addVideoProcessor</a>()</code> method.
           </li>
           <li>
             <!-- TODO: this should be defined better. -->
@@ -557,7 +582,8 @@
                 on which the method was invoked. (This is the <a>input media
                 stream track</a>.)
                 </li>
-                <li>Associate <var>worker</var> with <var>track</var>.
+                <li>Associate <var>worker</var> with <a>input media stream
+                track</a> <var>track</var>.
                 </li>
                 <li>Resolve <var>promise</var> with undefined.
                 </li>
@@ -604,20 +630,22 @@
                 <li>Let <var>worker</var> be the first method argument.
                 </li>
                 <li>Let <var>track</var> be the <a>MediaStreamTrack</a> object
-                on which the method was invoked.
+                on which the method was invoked. (This is the <a>input media
+                stream track</a>.)
                 </li>
                 <li>If there exists an association between <var>worker</var>
                 and <var>track</var>, reject promise with
                 <code>QuotaExceededError</code>.
                   <div class="note">
-                    A <a>MediaStreamTrack</a> owns at most one <a>video worker
-                    processor</a> at a time.
+                    A single <a>input media stream track</a> is associated with
+                    at most one <a>processing video worker</a> at a time.
                   </div>
                 </li>
-                <li>Associate <var>worker</var> with <var>track</var>.
+                <li>Associate <var>worker</var> with <a>input media stream
+                track</a> <var>track</var>.
                 </li>
                 <li>Let <var>new track</var> be a newly created
-                <a>MediaStreamTrack</a> object. (This is the <a>input media
+                <a>MediaStreamTrack</a> object. (This is the <a>output media
                 stream track</a>.)
                 </li>
                 <li>Associate <var>new track</var> as the <a>output media

--- a/index.html
+++ b/index.html
@@ -219,6 +219,16 @@
       <ul>
         <li>
           <dfn><a href=
+          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">
+          Event handler</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">
+          event handler event type</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
           "https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">
           event handler IDL attribute</a></dfn>
         </li>
@@ -370,9 +380,10 @@
             <li>If <var>e</var> is <a>videomonitor</a>, dispatch the newly
             created <a>VideoMonitorEvent</a> object at each <var>target</var>.
             </li>
-            <li>If <var>e</var> is <a>videoprocess</a>, initialize the
-            <a>outputImageBitmap</a> attribute to null, and dispatch the newly
-            created <a>VideoProceeEvent</a> object at each <var>target</var>.
+            <li link-for="VideoProcessorEvent">If <var>e</var> is
+            <a>videoprocess</a>, initialize the <a>outputImageBitmap</a>
+            attribute to null, and dispatch the newly created
+            <a>VideoProcessorEvent</a> object at each <var>target</var>.
             </li>
           </ol>
         </section>
@@ -441,7 +452,7 @@
             time <code>MediaStream</code>.
           </p>
         </div>
-        <p>
+        <p link-for="VideoProcessorEvent">
           <dfn>Video processor events</dfn> use the <a>VideoProcessorEvent</a>
           interface for their <a>videoprocess</a> events:
         </p>

--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
         worker source</a>.
       </p>
       <p>
-        There are two kinds of <dfn title="video worker source">video worker
+        There are two kinds of <dfn data-lt="video worker source">video worker
         sources</dfn>:
       </p>
       <dl>
@@ -329,7 +329,7 @@
             event</dfn> named <var>e</var>, it must run the following steps:
           </p>
         </div>
-        <ol>
+        <ol link-for="VideoMonitorEvent">
           <li>Create a <a>VideoMonitorEvent</a>, initialize it to have a name
           <a>videoprocess</a>, to not bubble, to not be cancelable.
           </li>
@@ -345,7 +345,7 @@
           stream position at <a>playbackTime</a>.
           </li>
           <li>Dispatch the newly created <a>VideoMonitorEvent</a> object at the
-          <a>DedicatedWorkerGlobalScope</a> of the <a title=
+          <a>DedicatedWorkerGlobalScope</a> of the <a data-lt=
           "video worker">video workers</a> that share the same <a>video worker
           source</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -442,16 +442,6 @@
           <code id="event-videoprocessorevent">VideoProcessorEvent</code>
           interface
         </h2>
-        <div class="note">
-          <p>
-            Ideally the <code>MediaStreamTrack</code> should dispatch each
-            video frame through <a>VideoProcessorEvent</a>. But sometimes the
-            worker thread could not process the frame in time. So the
-            implementation could skip the frame to avoid high memory footprint.
-            In such case, we might not be able to process every frame in a real
-            time <code>MediaStream</code>.
-          </p>
-        </div>
         <p link-for="VideoProcessorEvent">
           <dfn>Video processor events</dfn> use the <a>VideoProcessorEvent</a>
           interface for their <a>videoprocess</a> events:
@@ -495,6 +485,16 @@
           event</dfn>, it must <a>fire a video worker event</a> named
           <a>videoprocess</a>.
         </p>
+        <div class="note">
+          <p>
+            Ideally the <code>MediaStreamTrack</code> should dispatch each
+            video frame through <a>VideoProcessorEvent</a>. But sometimes the
+            worker thread could not process the frame in time. So the
+            implementation could skip the frame to avoid high memory footprint.
+            In such case, we might not be able to process every frame in a real
+            time <code>MediaStream</code>.
+          </p>
+        </div>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -266,21 +266,57 @@
         <p link-for="DedicatedWorkerGlobalScope">
           To enable generating, processing, and analyzing of video data
           directly using JavaScript in a worker, the
-          <a>DedicatedWorkerGlobalScope</a> interface is extended with a
-          <a>onvideoprocess</a> <a>event handler IDL attribute</a>. <a>Video
-          monitor events</a> and <a>video processor events</a> are dispatched
-          at the <a>DedicatedWorkerGlobalScope</a> object.
+          <a>DedicatedWorkerGlobalScope</a> interface is extended with an
+          <a>onvideomonitor</a> and <a>onvideoprocess</a> <a>event handler IDL
+          attribute</a>. <a>Video monitor events</a> and <a>video processor
+          events</a> are dispatched at the <a>DedicatedWorkerGlobalScope</a>
+          object.
         </p>
         <pre class="idl">
           partial interface DedicatedWorkerGlobalScope {
+                          attribute EventHandler onvideomonitor;
                           attribute EventHandler onvideoprocess;
           };
         </pre>
-        <p dfn-for="DedicatedWorkerGlobalScope">
-          The <dfn><code>onvideoprocess</code></dfn> is an <a>event handler IDL
-          attribute</a> for the <dfn><code>videoprocess</code></dfn> event
-          type.
-        </p>
+        <div dfn-for="DedicatedWorkerGlobalScope">
+          <p>
+            The following are the <a data-lt="event handler">event handlers</a>
+            (and their corresponding <a data-lt=
+            "event handler event type">event handler event types</a>) that must
+            be supported, as event handler IDL attributes, by objects
+            implementing the <a>DedicatedWorkerGlobalScope</a> interface:
+          </p>
+          <table class="simple">
+            <thead>
+              <tr>
+                <th>
+                  Event handlers
+                </th>
+                <th>
+                  <a>Event handler event type</a>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <dfn><code>onvideomonitor</code></dfn>
+                </td>
+                <td>
+                  <dfn><code>videomonitor</code></dfn>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <dfn><code>onvideoprocess</code></dfn>
+                </td>
+                <td>
+                  <dfn><code>videoprocess</code></dfn>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
       <section>
         <h2>
@@ -288,7 +324,7 @@
         </h2>
         <p>
           <dfn>Video monitor events</dfn> use the <a>VideoMonitorEvent</a>
-          interface for their <a>videoprocess</a> events:
+          interface for their <a>videomonitor</a> events:
         </p>
         <pre class="idl">
           [Constructor(DOMString type, optional VideoMonitorEventInit videoMonitorEventInitDict), Exposed=Worker]

--- a/index.html
+++ b/index.html
@@ -262,13 +262,12 @@
           interface VideoMonitorEvent : Event {
               readonly    attribute DOMString   trackId;
               readonly    attribute double      playbackTime;
-              readonly    attribute ImageBitmap inputImageBitmap;
+              readonly    attribute ImageBitmap? inputImageBitmap;
           };
-
           dictionary VideoMonitorEventInit : EventInit {
-            DOMString   trackId;
-            double      playbackTime;
-            ImageBitmap inputImageBitmap;
+              required DOMString    trackId;
+              required double       playbackTime;
+              required ImageBitmap? inputImageBitmap;
           };
         </pre>
         <div dfn-for="VideoMonitorEvent">
@@ -303,11 +302,12 @@
             <var>w</var> as an argument.
           </p>
           <p>
-            When a user agent is required to <dfn>fire a video monitor
-            event</dfn>, it must run the following steps:
+            When a user agent is required to <dfn>fire a video worker
+            event</dfn> named <var>e</var>, it must run the following steps:
           </p>
         </div>
-        <ol link-for="VideoMonitorEvent">
+        <ol>
+          <li>
           <li>Create a <a>VideoMonitorEvent</a>, initialize it to have a name
           <a>videoprocess</a>, to not bubble, to not be cancelable.
           </li>

--- a/index.html
+++ b/index.html
@@ -196,7 +196,9 @@
         <dfn>MediaStreamTrack</dfn></a></code> and <code><a href=
         "http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaStream">
         <dfn>MediaStream</dfn></a></code> interfaces this specification extends
-        are defined in [[!GETUSERMEDIA]].
+        and the <a href=
+        "http://w3c.github.io/mediacapture-main/#dfn-source"><dfn>source</dfn></a>
+        concept are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         The <code><a href=
@@ -242,7 +244,9 @@
           A <a>MediaStreamTrack</a> object is said to be a <a>video monitor
           source</a> for a worker <var>w</var>, if its
           <code>addVideoMonitor()</code> method has been invoked with
-          <var>w</var> as an argument.
+          <var>w</var> as an argument. This association is cleared if
+          <code>removeVideoMonitor()</code> method is invoked with <var>w</var>
+          as an argument.
         </dd>
         <dt>
           <dfn>Video processor source</dfn>
@@ -251,6 +255,8 @@
           A <a>MediaStreamTrack</a> object is said to be a <a>video processor
           source</a> for a worker <var>w</var>, if its
           <code>addVideoProcessor()</code> method has been invoked with
+          <var>w</var> as an argument. This association is cleared if
+          <code>removeVideoProcessor()</code> method is invoked with
           <var>w</var> as an argument.
         </dd>
       </dl>
@@ -425,40 +431,59 @@
           <code id="event-videoprocessorevent">VideoProcessorEvent</code>
           interface
         </h2>
+        <div class="note">
+          <p>
+            Ideally the <code>MediaStreamTrack</code> should dispatch each
+            video frame through <a>VideoProcessorEvent</a>. But sometimes the
+            worker thread could not process the frame in time. So the
+            implementation could skip the frame to avoid high memory footprint.
+            In such case, we might not be able to process every frame in a real
+            time <code>MediaStream</code>.
+          </p>
+        </div>
         <p>
-          This event is inherited from <code><a>VideoMonitorEvent</a></code>.
-          When the <code>MediaStreamTrack</code> comes a new video frame data,
-          the User Agent will dispatch a <code>VideoProcessorEvent</code> to
-          the associated Workers when the association is connected by
-          <code>addVideoProcessor</code>. The event handlers of those Workers
-          process video from the input by accessing the video data from the
-          <code>inputImageBitmap</code> attribute in the
-          <code>VideoProcessorEvent</code>. The processed video data which is
-          the result of the processing is then placed into the
-          <code>outputImageBitmap</code>. The User Agent will append the
-          <code>outputImageBitmap</code> into the new created
-          <code>MediaStreamTrack</code>.
+          <dfn>Video processor events</dfn> use the <a>VideoProcessorEvent</a>
+          interface for their <a>videoprocess</a> events:
         </p>
+        <pre class="idl">
+          [Constructor(DOMString type, optional VideoProcessorEventInit videoProcessorEventInitDict),
+           Exposed=Worker]
+          interface VideoProcessorEvent : VideoMonitorEvent {
+                          attribute ImageBitmap? outputImageBitmap;
+          };
+
+          dictionary VideoProcessorEventInit : EventInit {
+              required ImageBitmap? outputImageBitmap;
+          };
+        </pre>
+        <div dfn-for="VideoProcessorEvent">
+          <p>
+            The <dfn>outputImageBitmap</dfn> attribute must return the value it
+            was initialized to. When the object is created, this attribute must
+            be initialized to null. It represents the <a>ImageBitmap</a> object
+            which on setting, must cause the user agent to run the following
+            steps:
+          </p>
+        </div>
+        <ol link-for="VideoProcessorEvent">
+          <li>Let <var>output bitmap</var> be the <a>ImageBitmap</a> object
+          assigned to the <a>outputImageBitmap</a> attribute.
+          </li>
+          <li>Let <var>output media stream track</var> be the
+          <a>MediaStreamTrack</a> returned by the
+          <code>addVideoProcessor()</code> method.
+          </li>
+          <li>
+            <!-- TODO: this should be defined better. -->
+            Set <var>output bitmap</var> as the <a>source</a> of the
+            <var>output media stream track</var>.
+          </li>
+        </ol>
         <p>
-          Ideally the <code>MediaStreamTrack</code> should dispatch each video
-          frame through <a>VideoProcessorEvent</a>. But sometimes the worker
-          thread could not process the frame in time. So the implementation
-          could skip the frame to avoid high memory footprint. In such case, we
-          might not be able to process every frame in a real time
-          <code>MediaStream</code>.
+          When a user agent is required to <dfn>fire a video processor
+          event</dfn>, it must <a>fire a video worker event</a> named
+          <a>videoprocess</a>.
         </p>
-        <dl class="idl" title=
-        "[Exposed=Worker] interface VideoProcessorEvent : VideoMonitorEvent">
-          <dt>
-            attribute ImageBitmap? outputImageBitmap
-          </dt>
-          <dd>
-            The output video frame comes to the corresponding
-            <code>MediaStreamTrack</code>. It is default to be null. The Web
-            developer need to create a new <code>ImageBitmap</code> for output
-            frame and assign it to <code>outputImageBitmap</code>.
-          </dd>
-        </dl>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,13 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
   <head>
-    <title>Media Capture Stream with Worker</title>
+    <title>
+      Media Capture Stream with Worker
+    </title>
     <meta charset='utf-8'>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
-            async class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async
+    class='remove'>
+    </script>
     <script class='remove'>
       var respecConfig = {
           // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
@@ -40,20 +43,20 @@
           editors:  [
               {
                   name:       "Chia-hung Tai"
-//              ,   url:        "http://example.org/"
+    //              ,   url:        "http://example.org/"
               ,   mailto:     "ctai@mozilla.com"
               ,   company:    "Mozilla"
               ,   companyURL: "https://www.mozilla.org/en-US/foundation/moco/"
               },
               {
                   name:       "Robert O'Callahan"
-//              ,   url:        "http://example.org/"
+    //              ,   url:        "http://example.org/"
               ,   company:    "Mozilla"
               ,   companyURL: "https://www.mozilla.org/en-US/foundation/moco/"
               },
               {
                   name:       "Tzuhao Kuo"
-//              ,   url:        "http://example.org/"
+    //              ,   url:        "http://example.org/"
               ,   mailto:     "tkuo@mozilla.com"
               ,   company:    "Mozilla"
               ,   companyURL: "https://www.mozilla.org/en-US/foundation/moco/"
@@ -90,33 +93,34 @@
         process video frame data in workers on the web applications.
       </p>
     </section>
-
     <section id='sotd'>
-      <p><strong>
-        This document is not complete and is subject to change. Early
+      <p>
+        <strong>This document is not complete and is subject to change. Early
         experimentations are encouraged to allow the Media Capture Task Force
         to evolve the specification based on technical discussions within the
         Task Force, implementation experience gained from early
         implementations, and feedback from other groups and
-        individuals.
-      </strong></p>
-      <p><strong>
-        This specification is started in the Media Capture Task Force to get it
-        under way in anticipation of the <a href=
+        individuals.</strong>
+      </p>
+      <p>
+        <strong>This specification is started in the Media Capture Task Force
+        to get it under way in anticipation of the <a href=
         "http://www.w3.org/2015/07/timed-media-wg.html">Timed Media Working
         Group</a> creation. The intention is to transfer this specification to
-        the Timed Media Working Group when the group is formed.
-      </strong></p>
-      <p><strong>
-        This specification will use the <a href=
+        the Timed Media Working Group when the group is formed.</strong>
+      </p>
+      <p>
+        <strong>This specification will use the <a href=
         "http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.html">
         W3C Software and Document license</a> to be consistent with the
-        <a href="http://www.w3.org/2015/07/timed-media-wg.html#licensing">
-        licensing terms</a> of the proposed Timed Media Working Group.
-    </strong></p>
+        <a href="http://www.w3.org/2015/07/timed-media-wg.html#licensing">licensing
+        terms</a> of the proposed Timed Media Working Group.</strong>
+      </p>
     </section>
     <section>
-      <h2>Introduction</h2>
+      <h2>
+        Introduction
+      </h2>
       <p>
         The <em>Media Capture and Streams</em> specification provides a way to
         access to the video camera. But how to process the video frame data in
@@ -130,8 +134,8 @@
         data directly using JavaScript in a Worker thread.
       </p>
       <p>
-        <img alt= "The relationship between Worker and MediaStreamTrack"
-        src= "images/Worker - FLOW.png" style="width:60%">
+        <img alt="The relationship between Worker and MediaStreamTrack" src=
+        "images/Worker%20-%20FLOW.png" style="width:60%">
       </p>
       <p>
         The design principle of this specification is to provide a push-like
@@ -144,16 +148,20 @@
       </p>
     </section>
     <section>
-      <h2>Use cases and requirements</h2>
+      <h2>
+        Use cases and requirements
+      </h2>
       <p>
-        This specification attempts to address the
-        <a href="https://wiki.mozilla.org/Project_FoxEye#Use_Cases">Use Cases
-        and Requirements </a>for expanding the Web potentials to image
-        processing and computer vision area.
+        This specification attempts to address the <a href=
+        "https://wiki.mozilla.org/Project_FoxEye#Use_Cases">Use Cases and
+        Requirements</a> for expanding the Web potentials to image processing
+        and computer vision area.
       </p>
     </section>
     <section>
-      <h2>Conformance</h2>
+      <h2>
+        Conformance
+      </h2>
       <p>
         This specification defines conformance criteria that apply to a single
         product: the <dfn>user agent</dfn> that implements the interfaces that
@@ -168,13 +176,15 @@
       <p>
         The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT",
         "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
-        document are to be interpreted as described in RFC2119. For readability,
-        these words do not appear in all uppercase letters in this
+        document are to be interpreted as described in RFC2119. For
+        readability, these words do not appear in all uppercase letters in this
         specification. [[!RFC2119]]
       </p>
     </section>
     <section>
-      <h2>Dependencies</h2>
+      <h2>
+        Dependencies
+      </h2>
       <p>
         The <code><a href=
         "http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaStreamTrack">
@@ -185,197 +195,203 @@
       </p>
       <p>
         The <code><a href=
-        "http://www.w3.org/TR/html51/webappapis.html#imagebitmap">
-        <dfn>ImageBitmap</dfn></a></code> interface
-        and <code><a href=
-        "http://www.w3.org/TR/html51/webappapis.html#imagebitmapfactories">
-        <dfn>ImageBitmapFactories</dfn></a></code> interface this specification
+        "http://www.w3.org/TR/html51/webappapis.html#imagebitmap"><dfn>ImageBitmap</dfn></a></code>
+        interface and <code><a href=
+        "http://www.w3.org/TR/html51/webappapis.html#imagebitmapfactories"><dfn>
+        ImageBitmapFactories</dfn></a></code> interface this specification
         extends are defined in [[!HTML51]].
       </p>
       <p>
         The <code><a href=
-        "http://www.w3.org/TR/WebIDL-1/#common-BufferSource">
-        <dfn>BufferSource</dfn></a></code> is defined in [[!WEBIDL]]
+        "http://www.w3.org/TR/WebIDL-1/#common-BufferSource"><dfn>BufferSource</dfn></a></code>
+        is defined in [[!WEBIDL]]
       </p>
     </section>
     <section>
-      <h2>Extensions</h2>
-        <section>
-          <h2>
-            <code>DedicatedWorkerGlobalScope</code> interface
-          </h2>
-          <p>
-            By extending <code>DedicatedWorkerGlobalScope</code> object
-            with a event handler, <code>onvideoprocess</code>, it is
-            enabled the generating, processing, and analyzing of video data
-            directly using JavaScript in a Worker thread.
-          </p>
-          <p>
-            The <code><a>DedicatedWorkerGlobalScope</a></code> is the "inside" of a
-            <code>Worker</code>. It must not exist if the interface's
-            relevant namespace object is not a
-            <code><a>DedicatedWorkerGlobalScope</a></code> object.
-          </p>
-          <dl class="idl" title="partial interface DedicatedWorkerGlobalScope">
-            <dt>
-              attribute EventHandler onvideoprocess
-            </dt>
-            <dd>
-              <p>
-                A property used to set the EventHandler (described in [[!HTML]])
-                for the <a><code>VideoMonitorEvent</code></a>/
-                <a><code>VideoProcessorEvent</code></a> that is dispatched
-                to <code><a>DedicatedWorkerGlobalScope</a></code> to process video
-                while the associated <code><a>MediaStreamTrack</a></code> are
-                connected. When a new input video frame is sent to corresponding
-                <code>MediaStreamTrack</code>, User Agent will create a
-                <code><a>VideoProcessEventThe</a></code> and dispatch it. Then the event
-                handler, of type <code><a>videoprocess</a></code>,
-                is executed .
-               </p>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <code id = event-videomonitorevent>VideoMonitorEvent</code> interface
-          </h2>
-          <p>
-            This is an <code>Event</code> object which is dispatched to
-            <a><code>DedicatedWorkerGlobalScope</code></a> objects to perform
-            processing.
-          </p>
-          <p>
-            When the <code>MediaStreamTrack</code> comes a new video frame data,
-            the User Agent will dispatch a <code><a>VideoMonitorEvent</a></code> to the
-            associated Workers when the association is connected by
-            <code>addVideoMonitor</code>. The event handlers of those Workers
-            process video from the input by accessing the video data from the
-            <code>inputImageBitmap</code> attribute in the
-            <code>VideoMonitorEvent</code>.
-          </p>
-          <p>
-            Ideally the <code>MediaStreamTrack</code> should dispatch each
-            video frame through <code><a>VideoMonitorEvent</a></code>. But sometimes the
-            worker thread could not process the frame in time. So the
-            implementation could skip the frame to avoid high memory footprint.
-            In such case, we might not be able to process every frame in a real
-            time <code>MediaStream</code>.
-          </p>
-          <dl class="idl" title="[Exposed=Worker] interface VideoMonitorEvent : Event">
-            <dt>
-              readonly attribute DOMString trackId
-            </dt>
-            <dd>
-              The <code>MediaStreamTrack.id</code> of corresponding
-              <code>MediaStreamTrack</code>.
-            </dd>
-            <dt>
-              readonly attribute double playbackTime
-            </dt>
-            <dd>
-              The elapsed time of the <code>MediaStreamTrack</code> from the
-              <code>MediaStream</code> starting.
-            </dd>
-            <dt>
-              readonly attribute ImageBitmap inputImageBitmap
-            </dt>
-            <dd>
-              The input video frame comes from the corresponding
-              <code>MediaStreamTrack</code>.
-            </dd>
-          </dl>
-        </section>
-                <section>
-          <h2>
-            <code id = event-videoprocessorevent>VideoProcessorEvent</code> interface
-          </h2>
-          <p>
-            This event is inherited from <code><a>VideoMonitorEvent</a></code>.
-            When the <code>MediaStreamTrack</code> comes a new video frame data,
-            the User Agent will dispatch a <code>VideoProcessorEvent</code> to the
-            associated Workers when the association is connected by
-            <code>addVideoProcessor</code>. The event handlers of those Workers
-            process video from the input by accessing the video data from the
-            <code>inputImageBitmap</code> attribute in the
-            <code>VideoProcessorEvent</code>. The processed video data which is
-            the result of the processing is then placed into the
-            <code>outputImageBitmap</code>. The User Agent will append the
-            <code>outputImageBitmap</code> into the new created
+      <h2>
+        Extensions
+      </h2>
+      <section>
+        <h2>
+          <code>DedicatedWorkerGlobalScope</code> interface
+        </h2>
+        <p>
+          By extending <code>DedicatedWorkerGlobalScope</code> object with a
+          event handler, <code>onvideoprocess</code>, it is enabled the
+          generating, processing, and analyzing of video data directly using
+          JavaScript in a Worker thread.
+        </p>
+        <p>
+          The <code><a>DedicatedWorkerGlobalScope</a></code> is the "inside" of
+          a <code>Worker</code>. It must not exist if the interface's relevant
+          namespace object is not a
+          <code><a>DedicatedWorkerGlobalScope</a></code> object.
+        </p>
+        <dl class="idl" title="partial interface DedicatedWorkerGlobalScope">
+          <dt>
+            attribute EventHandler onvideoprocess
+          </dt>
+          <dd>
+            <p>
+              A property used to set the EventHandler (described in [[!HTML]])
+              for the <a><code>VideoMonitorEvent</code></a>/
+              <a><code>VideoProcessorEvent</code></a> that is dispatched to
+              <code><a>DedicatedWorkerGlobalScope</a></code> to process video
+              while the associated <code><a>MediaStreamTrack</a></code> are
+              connected. When a new input video frame is sent to corresponding
+              <code>MediaStreamTrack</code>, User Agent will create a
+              <code><a>VideoProcessEventThe</a></code> and dispatch it. Then
+              the event handler, of type <code><a>videoprocess</a></code>, is
+              executed .
+            </p>
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>
+          <code id="event-videomonitorevent">VideoMonitorEvent</code> interface
+        </h2>
+        <p>
+          This is an <code>Event</code> object which is dispatched to
+          <a><code>DedicatedWorkerGlobalScope</code></a> objects to perform
+          processing.
+        </p>
+        <p>
+          When the <code>MediaStreamTrack</code> comes a new video frame data,
+          the User Agent will dispatch a <code><a>VideoMonitorEvent</a></code>
+          to the associated Workers when the association is connected by
+          <code>addVideoMonitor</code>. The event handlers of those Workers
+          process video from the input by accessing the video data from the
+          <code>inputImageBitmap</code> attribute in the
+          <code>VideoMonitorEvent</code>.
+        </p>
+        <p>
+          Ideally the <code>MediaStreamTrack</code> should dispatch each video
+          frame through <code><a>VideoMonitorEvent</a></code>. But sometimes
+          the worker thread could not process the frame in time. So the
+          implementation could skip the frame to avoid high memory footprint.
+          In such case, we might not be able to process every frame in a real
+          time <code>MediaStream</code>.
+        </p>
+        <dl class="idl" title=
+        "[Exposed=Worker] interface VideoMonitorEvent : Event">
+          <dt>
+            readonly attribute DOMString trackId
+          </dt>
+          <dd>
+            The <code>MediaStreamTrack.id</code> of corresponding
             <code>MediaStreamTrack</code>.
-          </p>
-          <p>
-            Ideally the <code>MediaStreamTrack</code> should dispatch each
-            video frame through <a>VideoProcessorEvent</a>. But sometimes the
-            worker thread could not process the frame in time. So the
-            implementation could skip the frame to avoid high memory footprint.
-            In such case, we might not be able to process every frame in a real
-            time <code>MediaStream</code>.
-          </p>
-          <dl class="idl" title="[Exposed=Worker] interface VideoProcessorEvent : VideoMonitorEvent">
-            <dt>
-              attribute ImageBitmap? outputImageBitmap
-            </dt>
-            <dd>
-              The output video frame comes to the corresponding
-              <code>MediaStreamTrack</code>. It is default to be null. The Web
-              developer need to create a new <code>ImageBitmap</code> for output
-              frame and assign it to <code>outputImageBitmap</code>.
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <code>MediaStreamTrack</code> interface
-          </h2>
-          <dl class="idl" title="partial interface MediaStreamTrack">
-            <dt>
-              void addVideoMonitor(Worker worker)
-            </dt>
-            <dd>
-              Associate the <code>worker</code> with the <code>MediaStreamTrack</code>.
-              You can add the same <code>worker</code> to any other
-              <code>MediaStreamTrack</code>.
-            </dd>
-            <dt>
-              void removeVideoMonitor(Worker worker)
-            </dt>
-            <dd>
-              Remove a particular <code>Worker</code> from the
-              <code>MediaStreamTrack</code>. User Agent should throw exception
-              when the <code>Worker</code> is not exist in the
-              <code>MediaStreamTrack</code>.
-            </dd>
-            <dt>
-              MediaStreamTrack addVideoProcessor(Worker worker)
-            </dt>
-            <dd>
-              This method will create a new <code>MediaStreamTrack</code> and
-              take the original <code>MediaStreamTrack</code> as the input
-              source. Then associate the <code>Worker</code> with new created
-              <code>MediaStreamTrack</code>. The developers can build a
-              processed pipeline by this method.
-            </dd>
-            <dt>
-              void removeVideoProcessor()
-            </dt>
-            <dd>
-              Remove the added <code>Worker</code> from current
-              <code>MediaStreamTrack</code>. User Agent should throw exception
-              when the <code>Worker</code> is not exist in the
-              <code>MediaStreamTrack</code>. A <code>MediaStreamTrack</code>
-              owns at most one Worker processor in any time.
-            </dd>
-          </dl>
-        </section>
+          </dd>
+          <dt>
+            readonly attribute double playbackTime
+          </dt>
+          <dd>
+            The elapsed time of the <code>MediaStreamTrack</code> from the
+            <code>MediaStream</code> starting.
+          </dd>
+          <dt>
+            readonly attribute ImageBitmap inputImageBitmap
+          </dt>
+          <dd>
+            The input video frame comes from the corresponding
+            <code>MediaStreamTrack</code>.
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>
+          <code id="event-videoprocessorevent">VideoProcessorEvent</code>
+          interface
+        </h2>
+        <p>
+          This event is inherited from <code><a>VideoMonitorEvent</a></code>.
+          When the <code>MediaStreamTrack</code> comes a new video frame data,
+          the User Agent will dispatch a <code>VideoProcessorEvent</code> to
+          the associated Workers when the association is connected by
+          <code>addVideoProcessor</code>. The event handlers of those Workers
+          process video from the input by accessing the video data from the
+          <code>inputImageBitmap</code> attribute in the
+          <code>VideoProcessorEvent</code>. The processed video data which is
+          the result of the processing is then placed into the
+          <code>outputImageBitmap</code>. The User Agent will append the
+          <code>outputImageBitmap</code> into the new created
+          <code>MediaStreamTrack</code>.
+        </p>
+        <p>
+          Ideally the <code>MediaStreamTrack</code> should dispatch each video
+          frame through <a>VideoProcessorEvent</a>. But sometimes the worker
+          thread could not process the frame in time. So the implementation
+          could skip the frame to avoid high memory footprint. In such case, we
+          might not be able to process every frame in a real time
+          <code>MediaStream</code>.
+        </p>
+        <dl class="idl" title=
+        "[Exposed=Worker] interface VideoProcessorEvent : VideoMonitorEvent">
+          <dt>
+            attribute ImageBitmap? outputImageBitmap
+          </dt>
+          <dd>
+            The output video frame comes to the corresponding
+            <code>MediaStreamTrack</code>. It is default to be null. The Web
+            developer need to create a new <code>ImageBitmap</code> for output
+            frame and assign it to <code>outputImageBitmap</code>.
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>
+          <code>MediaStreamTrack</code> interface
+        </h2>
+        <dl class="idl" title="partial interface MediaStreamTrack">
+          <dt>
+            void addVideoMonitor(Worker worker)
+          </dt>
+          <dd>
+            Associate the <code>worker</code> with the
+            <code>MediaStreamTrack</code>. You can add the same
+            <code>worker</code> to any other <code>MediaStreamTrack</code>.
+          </dd>
+          <dt>
+            void removeVideoMonitor(Worker worker)
+          </dt>
+          <dd>
+            Remove a particular <code>Worker</code> from the
+            <code>MediaStreamTrack</code>. User Agent should throw exception
+            when the <code>Worker</code> is not exist in the
+            <code>MediaStreamTrack</code>.
+          </dd>
+          <dt>
+            MediaStreamTrack addVideoProcessor(Worker worker)
+          </dt>
+          <dd>
+            This method will create a new <code>MediaStreamTrack</code> and
+            take the original <code>MediaStreamTrack</code> as the input
+            source. Then associate the <code>Worker</code> with new created
+            <code>MediaStreamTrack</code>. The developers can build a processed
+            pipeline by this method.
+          </dd>
+          <dt>
+            void removeVideoProcessor()
+          </dt>
+          <dd>
+            Remove the added <code>Worker</code> from current
+            <code>MediaStreamTrack</code>. User Agent should throw exception
+            when the <code>Worker</code> is not exist in the
+            <code>MediaStreamTrack</code>. A <code>MediaStreamTrack</code> owns
+            at most one Worker processor in any time.
+          </dd>
+        </dl>
+      </section>
     </section>
     <section id='imagebitmap-extensions'>
-      <h2>ImageBitmap extensions</h2>
+      <h2>
+        ImageBitmap extensions
+      </h2>
       <div class="note">
         <p>
-          The <a>ImageBitmap</a> interface is originally designed as
-          a pure opaque handler to an image data buffer inside a browser so that
-          how the browser stores the buffer is uknown to users and optimized to
+          The <a>ImageBitmap</a> interface is originally designed as a pure
+          opaque handler to an image data buffer inside a browser so that how
+          the browser stores the buffer is uknown to users and optimized to
           platforms. In this specification, we chooses <a>ImageBitmap</a>
           (instead of <code>ImageData</code>) as the container of video frames
           because the decoded video frame data might exist in either CPU or GPU
@@ -386,23 +402,20 @@
       <p>
         Considering how would developers process video frames, there are two
         possible approaches, via pure JavaScript(/asm.js) code or via WebGL.
-        <ol>
-          <li>
-            If developers use JavaScript(/asm.js) to process the frames, then
-            the <a>ImageBitmap</a> interface needs to be extended with APIs for
-            developers to access its underlying data and there should also be a
-            way for developers to create an <a>ImageBitmap</a> from the
-            processed data.
-          </li>
-          <li>
-            If developers use WebGL, then WebGL needs to be extended so that
-            developers can pass an <a>ImageBitmap</a> into the WebGL context and
-            the browser will handle how to upload the raw image data into the
-            GPU memory. Possiblely, the data is already in the GPU memory so
-            that the operation could be very efficient.
-          </li>
-        </ol>
       </p>
+      <ol>
+        <li>If developers use JavaScript(/asm.js) to process the frames, then
+        the <a>ImageBitmap</a> interface needs to be extended with APIs for
+        developers to access its underlying data and there should also be a way
+        for developers to create an <a>ImageBitmap</a> from the processed data.
+        </li>
+        <li>If developers use WebGL, then WebGL needs to be extended so that
+        developers can pass an <a>ImageBitmap</a> into the WebGL context and
+        the browser will handle how to upload the raw image data into the GPU
+        memory. Possiblely, the data is already in the GPU memory so that the
+        operation could be very efficient.
+        </li>
+      </ol>
       <p>
         In this specification, the original <a>ImageBitmap</a> interface is
         extended with three methods to let developers read data from an
@@ -410,76 +423,72 @@
         supported <a>ImageFormat</a>s and two interfaces,
         <a>ImageFormatPixelLayout</a> and <a>ChannelPixelLayout</a>, are
         proposed to work with the extend <a>ImageBitmap</a> methods to describe
-        how the accessed image data is arranged in memory. Also,
-        the <a>ImageBitmapFactories</a> interface is extended to let developers
+        how the accessed image data is arranged in memory. Also, the
+        <a>ImageBitmapFactories</a> interface is extended to let developers
         create an <a>ImageBitmap</a> object from a given <a>BufferSource</a>.
       </p>
       <section id='imageformat'>
-        <h2>ImageFormat</h2>
+        <h2>
+          ImageFormat
+        </h2>
         <p>
           An image or a video frame is conceptually a two-dimentional array of
           data and each element in the array is called a <dfn>pixel</dfn>.
           However, the pixels are usually stored in a one-dimentional array and
-          could be arranged in a variety of <a>ImageFormat</a>s.
-          Developers need to know how the pixels are formatted so that they are
-          able to process it.
-
-          An <a>ImageFormat</a> describes how pixels in an image are arranged
-          and all pixels in one single image are arranged in the same way.
-          A single pixel has at least one, but usually multiple
-          <dfn>pixel value</dfn>s.
-          The range of a pixel value varies, which means different
-          <a>ImageFormat</a>s use different <dfn>data type</dfn>s to store a
-          single pixel value.
-          The most frequently used data type is 8-bit unsigned interger whose
-          range is from 0 to 255, others could be 16-bit interger or 32-bit
-          folating points and so forth.
-          The number of pixle values of a single pixel is called the number of
-          <dfn>channel</dfn>s of the <a>ImageFormat</a>.
-          Multiple pixel valuse of a pixel are used together to describe the
-          captured property which could be color or depth information.
-          For example, if the data is a color image in RGB color space, then it
-          is a three-channel <a>ImageFormat</a> and a pixel is described by R, G
-          and B three pixel values with range from 0 to 255.
-          Another example, if the data is a gray image, then it is a
-          single-channel <a>ImageFormat</a> with 8-bit unsigned interger data
-          type and the pixel value describes the gray scale.
-          For depth data, it is a single channel <a>ImageFormat</a> too, but the
-          data type is 16-bit unsigned interger and the pixel value is the depth
-          level.
-
-          For those <a>ImageFormat</a>s whose pixels contain multiple pixel
-          values, the pixel values might be arranged in a planar way or
-          interleaving way:
-          <ol>
-            <li>
-              <dfn>Planar pixel layout</dfn>: each channel has its pixel values
-              stored consecutively in separated buffers (a.k.a. planes) and then
-              all channel buffers are stored consecutively in memory.
-              (Ex: RRRRRR......GGGGGG......BBBBBB......)
-            </li>
-            <li>
-              <dfn>Interleaving pixel layout</dfn>: each pixel has its pixel
-              values from all channels stored together and interleaves all
-              channels.
-              (Ex: RGBRGBRGBRGBRGB......)
-            </li>
-          </ol>
-          <div class="note">
-            <p>
-              <a>ImageFormat</a>s belong to the same color space might have
-              different pixel layouts.
-            </p>
-          </div>
+          could be arranged in a variety of <a>ImageFormat</a>s. Developers
+          need to know how the pixels are formatted so that they are able to
+          process it. An <a>ImageFormat</a> describes how pixels in an image
+          are arranged and all pixels in one single image are arranged in the
+          same way. A single pixel has at least one, but usually multiple
+          <dfn>pixel value</dfn>s. The range of a pixel value varies, which
+          means different <a>ImageFormat</a>s use different <dfn>data
+          type</dfn>s to store a single pixel value. The most frequently used
+          data type is 8-bit unsigned interger whose range is from 0 to 255,
+          others could be 16-bit interger or 32-bit folating points and so
+          forth. The number of pixle values of a single pixel is called the
+          number of <dfn>channel</dfn>s of the <a>ImageFormat</a>. Multiple
+          pixel valuse of a pixel are used together to describe the captured
+          property which could be color or depth information. For example, if
+          the data is a color image in RGB color space, then it is a
+          three-channel <a>ImageFormat</a> and a pixel is described by R, G and
+          B three pixel values with range from 0 to 255. Another example, if
+          the data is a gray image, then it is a single-channel
+          <a>ImageFormat</a> with 8-bit unsigned interger data type and the
+          pixel value describes the gray scale. For depth data, it is a single
+          channel <a>ImageFormat</a> too, but the data type is 16-bit unsigned
+          interger and the pixel value is the depth level. For those
+          <a>ImageFormat</a>s whose pixels contain multiple pixel values, the
+          pixel values might be arranged in a planar way or interleaving way:
         </p>
+        <ol>
+          <li>
+            <dfn>Planar pixel layout</dfn>: each channel has its pixel values
+            stored consecutively in separated buffers (a.k.a. planes) and then
+            all channel buffers are stored consecutively in memory. (Ex:
+            RRRRRR......GGGGGG......BBBBBB......)
+          </li>
+          <li>
+            <dfn>Interleaving pixel layout</dfn>: each pixel has its pixel
+            values from all channels stored together and interleaves all
+            channels. (Ex: RGBRGBRGBRGBRGB......)
+          </li>
+        </ol>
+        <div class="note">
+          <p>
+            <a>ImageFormat</a>s belong to the same color space might have
+            different pixel layouts.
+          </p>
+        </div>
         <section id='imageformat-enumaration'>
-          <h2><code>ImageFormat</code> enumeration</h2>
+          <h2>
+            <code>ImageFormat</code> enumeration
+          </h2>
           <p>
             An enumeration <a>ImageFormat</a> defines a list of image formats
-            which are supported by the browser and  exposed to users. The extend
+            which are supported by the browser and exposed to users. The extend
             APIs in this specification use this enumeration to negotiate the
-            format while accessing the underlying data of <a>ImageBitmap</a> and
-            creating a new <a>ImageBitmap</a>.
+            format while accessing the underlying data of <a>ImageBitmap</a>
+            and creating a new <a>ImageBitmap</a>.
           </p>
           <div class="note">
             <p>
@@ -487,151 +496,293 @@
             </p>
           </div>
           <dl id="enum-basic" class="idl" title="enum ImageFormat">
-            <dt>RGBA32</dt>
+            <dt>
+              RGBA32
+            </dt>
             <dd>
-              <p>Channel order: R, G, B, A</p>
-              <p>Channel size: full rgba-chennels</p>
-              <p>Pixel layout: interleaving rgba-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: R, G, B, A
+              </p>
+              <p>
+                Channel size: full rgba-chennels
+              </p>
+              <p>
+                Pixel layout: interleaving rgba-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>BGRA32</dt>
+            <dt>
+              BGRA32
+            </dt>
             <dd>
-              <p>Channel order: B, G, R, A</p>
-              <p>Channel size: full bgra-channels</p>
-              <p>Pixel layout: interleaving bgra-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: B, G, R, A
+              </p>
+              <p>
+                Channel size: full bgra-channels
+              </p>
+              <p>
+                Pixel layout: interleaving bgra-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>RGB24</dt>
+            <dt>
+              RGB24
+            </dt>
             <dd>
-              <p>Channel order: R, G, B</p>
-              <p>Channel size: full rgb-channels</p>
-              <p>Pixel layout: interleaving rgb-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: R, G, B
+              </p>
+              <p>
+                Channel size: full rgb-channels
+              </p>
+              <p>
+                Pixel layout: interleaving rgb-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>BGR24</dt>
+            <dt>
+              BGR24
+            </dt>
             <dd>
-              <p>Channel order: B, G, R</p>
-              <p>Channel size: full bgr-channels</p>
-              <p>Pixel layout: interleaving bgr-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: B, G, R
+              </p>
+              <p>
+                Channel size: full bgr-channels
+              </p>
+              <p>
+                Pixel layout: interleaving bgr-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>GRAY8</dt>
+            <dt>
+              GRAY8
+            </dt>
             <dd>
-              <p>Channel order: GRAY</p>
-              <p>Channel size: full gray-channel</p>
-              <p>Pixel layout: planar gray-channel</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: GRAY
+              </p>
+              <p>
+                Channel size: full gray-channel
+              </p>
+              <p>
+                Pixel layout: planar gray-channel
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>YUV444P</dt>
+            <dt>
+              YUV444P
+            </dt>
             <dd>
-              <p>Channel order: Y, U, V</p>
-              <p>Channel size: full yuv-channels</p>
-              <p>Pixel layout: planar yuv-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: Y, U, V
+              </p>
+              <p>
+                Channel size: full yuv-channels
+              </p>
+              <p>
+                Pixel layout: planar yuv-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>YUV422P</dt>
+            <dt>
+              YUV422P
+            </dt>
             <dd>
-              <p>Channel order: Y, U, V</p>
-              <p>Channel size: full y-channel, half uv-channels</p>
-              <p>Pixel layout: planar yuv-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: Y, U, V
+              </p>
+              <p>
+                Channel size: full y-channel, half uv-channels
+              </p>
+              <p>
+                Pixel layout: planar yuv-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>YUV420P</dt>
+            <dt>
+              YUV420P
+            </dt>
             <dd>
-              <p>Channel order: Y, U, V</p>
-              <p>Channel size: full y-channel, quarter uv-channels</p>
-              <p>Pixel layout: planar yuv-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: Y, U, V
+              </p>
+              <p>
+                Channel size: full y-channel, quarter uv-channels
+              </p>
+              <p>
+                Pixel layout: planar yuv-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>YUV420SP_NV12</dt>
+            <dt>
+              YUV420SP_NV12
+            </dt>
             <dd>
-              <p>Channel order: Y, U, V</p>
-              <p>Channel size: full y-channel, quarter uv-channels</p>
-              <p>Pixel layout: planar y-channel, interleaving uv-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: Y, U, V
+              </p>
+              <p>
+                Channel size: full y-channel, quarter uv-channels
+              </p>
+              <p>
+                Pixel layout: planar y-channel, interleaving uv-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>YUV420SP_NV21</dt>
+            <dt>
+              YUV420SP_NV21
+            </dt>
             <dd>
-              <p>Channel order: Y, V, U</p>
-              <p>Channel size: full y-channel, quarter uv-channels</p>
-              <p>Pixel layout: planar y-channel, interleaving vu-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: Y, V, U
+              </p>
+              <p>
+                Channel size: full y-channel, quarter uv-channels
+              </p>
+              <p>
+                Pixel layout: planar y-channel, interleaving vu-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>HSV</dt>
+            <dt>
+              HSV
+            </dt>
             <dd>
-              <p>Channel order: H, S, V</p>
-              <p>Channel size: full hsv-channels</p>
-              <p>Pixel layout: interleaving hsv-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: H, S, V
+              </p>
+              <p>
+                Channel size: full hsv-channels
+              </p>
+              <p>
+                Pixel layout: interleaving hsv-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>Lab</dt>
+            <dt>
+              Lab
+            </dt>
             <dd>
-              <p>Channel order: l, a, b</p>
-              <p>Channel size: full lab-channels</p>
-              <p>Pixel layout: interleaving lab-channels</p>
-              <p>Data type: 8-bit unsigned integer</p>
+              <p>
+                Channel order: l, a, b
+              </p>
+              <p>
+                Channel size: full lab-channels
+              </p>
+              <p>
+                Pixel layout: interleaving lab-channels
+              </p>
+              <p>
+                Data type: 8-bit unsigned integer
+              </p>
             </dd>
-            <dt>DEPTH</dt>
+            <dt>
+              DEPTH
+            </dt>
             <dd>
-              <p>Channel order: DEPTH</p>
-              <p>Channel size: full depth-channel</p>
-              <p>Pixel layout: planar depth-channel</p>
-              <p>Data type: 16-bit unsigned integer</p>
+              <p>
+                Channel order: DEPTH
+              </p>
+              <p>
+                Channel size: full depth-channel
+              </p>
+              <p>
+                Pixel layout: planar depth-channel
+              </p>
+              <p>
+                Data type: 16-bit unsigned integer
+              </p>
             </dd>
           </dl>
         </section>
         <section id='datatype-enumeration'>
-          <h2><code>DataType</code> enumeration</h2>
+          <h2>
+            <code>DataType</code> enumeration
+          </h2>
           <p>
             An enumeration <a>DataType</a> defines a list of data types that is
             used to store a single <a>pixel value</a>.
           </p>
           <dl id="enum-basic" class="idl" title="enum DataType">
-            <dt>uint8</dt>
+            <dt>
+              uint8
+            </dt>
             <dd>
               8-bit unsigned integer.
             </dd>
-
-            <dt>int8</dt>
+            <dt>
+              int8
+            </dt>
             <dd>
               8-bit integer.
             </dd>
-
-            <dt>uint16</dt>
+            <dt>
+              uint16
+            </dt>
             <dd>
               16-bit unsigned integer.
             </dd>
-
-            <dt>int16</dt>
+            <dt>
+              int16
+            </dt>
             <dd>
               16-bit integer.
             </dd>
-
-            <dt>uint32</dt>
+            <dt>
+              uint32
+            </dt>
             <dd>
               32-bit unsigned integer.
             </dd>
-
-            <dt>int32</dt>
+            <dt>
+              int32
+            </dt>
             <dd>
               32-bit integer.
             </dd>
-
-            <dt>float32</dt>
+            <dt>
+              float32
+            </dt>
             <dd>
               32-bit IEEE floating point number.
             </dd>
-
-            <dt>float64</dt>
+            <dt>
+              float64
+            </dt>
             <dd>
               64-bit IEEE floating point number.
             </dd>
-
           </dl>
         </section>
       </section>
       <section id='pixellayout'>
-        <h2>PixelLayout</h2>
+        <h2>
+          PixelLayout
+        </h2>
         <p>
           Two interfaces, <a>ImageFormatPixelLayout</a> and
           <a>ChannelPixelLayout</a>, help together to generalize the variety of
@@ -640,41 +791,40 @@
         <p>
           The <a>ImageFormatPixelLayout</a> represents the pixel layout of a
           certain image format and since a image format is composed by at least
-          one <a>channel</a> so an <a>ImageFormatPixelLayout</a> object contains
-          at least one <a>ChannelPixelLayout</a> object.
+          one <a>channel</a> so an <a>ImageFormatPixelLayout</a> object
+          contains at least one <a>ChannelPixelLayout</a> object.
         </p>
         <p>
-          Although an image or a video frame is a two-dimensional structure, its
-          data is usually stored in an one-dimensional array in the raw-major
-          way and the <a>ChannelPixelLayout</a> uses the following properties to
-          describe how pixel values are arranged in the one dimentional array
-          buffer.
-          <ol>
-            <li>
-              <strong>offset</strong>: where is each <a>channel</a>'s data
-              starts from.
-              (Relative to the beginning of the video data one-dimension array.)
-            </li>
-            <li>
-              <strong>width</strong> and <strong>height</strong>:
-              how much samples are in each channel.
-            </li>
-            <li>
-              <strong>data type</strong>: the data type used to store one single
-              <a>pixel value</a>.
-            </li>
-            <li>
-              <strong>stride</strong>: the total bytes of each raw plus the
-              padding bytes of each row.
-            </li>
-            <li>
-              <strong>skip</strong>: this is used to describe <a>interleaving
-              pixel layout</a>. (For <a>planar pixel layout</a>, this property
-              will be zero.)
-            </li>
-          </ol>
+          Although an image or a video frame is a two-dimensional structure,
+          its data is usually stored in an one-dimensional array in the
+          raw-major way and the <a>ChannelPixelLayout</a> uses the following
+          properties to describe how pixel values are arranged in the one
+          dimentional array buffer.
         </p>
-
+        <ol>
+          <li>
+            <strong>offset</strong>: where is each <a>channel</a>'s data starts
+            from. (Relative to the beginning of the video data one-dimension
+            array.)
+          </li>
+          <li>
+            <strong>width</strong> and <strong>height</strong>: how much
+            samples are in each channel.
+          </li>
+          <li>
+            <strong>data type</strong>: the data type used to store one single
+            <a>pixel value</a>.
+          </li>
+          <li>
+            <strong>stride</strong>: the total bytes of each raw plus the
+            padding bytes of each row.
+          </li>
+          <li>
+            <strong>skip</strong>: this is used to describe <a>interleaving
+            pixel layout</a>. (For <a>planar pixel layout</a>, this property
+            will be zero.)
+          </li>
+        </ol>
         <pre class='example highlight'>
           Example1: RGBA image, width = 620, height = 480, stride = 2560
 
@@ -683,8 +833,8 @@
           chanel_b: offset = 2, width = 620, height = 480, data type = uint8, stride = 2560, skip = 3
           chanel_a: offset = 3, width = 620, height = 480, data type = uint8, stride = 2560, skip = 3
 
-                  <---------------------------- stride ---------------------------->
-                  <---------------------- width x 4 ---------------------->
+                  &lt;---------------------------- stride ----------------------------&gt;
+                  &lt;---------------------- width x 4 ----------------------&gt;
           [index] 01234   8   12  16  20  24  28                           2479    2559
                   |||||---|---|---|---|---|---|----------------------------|-------|
           [data]  RGBARGBARGBARGBARGBAR___R___R...                         A%%%%%%%%
@@ -693,7 +843,6 @@
                        ^^^
                        r-skip
         </pre>
-
         <pre class='example highlight'>
           Example2: YUV420P image, width = 620, height = 480, stride = 640
 
@@ -701,24 +850,24 @@
           chanel_u: offset = 307200, width = 310, height = 240, data type = uint8, stride = 320, skip = 0
           chanel_v: offset = 384000, width = 310, height = 240, data type = uint8, stride = 320, skip = 0
 
-                  <--------------------------- y-stride --------------------------->
-                  <----------------------- y-width ----------------------->
+                  &lt;--------------------------- y-stride ---------------------------&gt;
+                  &lt;----------------------- y-width -----------------------&gt;
           [index] 012345                                                  619      639
                   ||||||--------------------------------------------------|--------|
           [data]  YYYYYYYYYYYYYYYYYYYYYYYYYYYYY...                        Y%%%%%%%%%
           [data]  YYYYYYYYYYYYYYYYYYYYYYYYYYYYY...                        Y%%%%%%%%%
           [data]  YYYYYYYYYYYYYYYYYYYYYYYYYYYYY...                        Y%%%%%%%%%
           [data]  ......
-                  <-------- u-stride ---------->
-                  <----- u-width ----->
+                  &lt;-------- u-stride ----------&gt;
+                  &lt;----- u-width -----&gt;
           [index] 307200              307509   307519
                   |-------------------|--------|
           [data]  UUUUUUUUUU...       U%%%%%%%%%
           [data]  UUUUUUUUUU...       U%%%%%%%%%
           [data]  UUUUUUUUUU...       U%%%%%%%%%
           [data]  ......
-                  <-------- v-stride ---------->
-                  <- --- v-width ----->
+                  &lt;-------- v-stride ----------&gt;
+                  &lt;- --- v-width -----&gt;
           [index] 384000              384309   384319
                   |-------------------|--------|
           [data]  VVVVVVVVVV...       V%%%%%%%%%
@@ -726,7 +875,6 @@
           [data]  VVVVVVVVVV...       V%%%%%%%%%
           [data]  ......
         </pre>
-
         <pre class='example highlight'>
           Example3: YUV420SP_NV12 image, width = 620, height = 480, stride = 640
 
@@ -734,16 +882,16 @@
           chanel_u: offset = 307200, width = 310, height = 240, data type = uint8, stride = 640, skip = 1
           chanel_v: offset = 307201, width = 310, height = 240, data type = uint8, stride = 640, skip = 1
 
-                  <--------------------------- y-stride -------------------------->
-                  <----------------------- y-width ---------------------->
+                  &lt;--------------------------- y-stride --------------------------&gt;
+                  &lt;----------------------- y-width ----------------------&gt;
           [index] 012345                                                 619      639
                   ||||||-------------------------------------------------|--------|
           [data]  YYYYYYYYYYYYYYYYYYYYYYYYYYYYY...                       Y%%%%%%%%%
           [data]  YYYYYYYYYYYYYYYYYYYYYYYYYYYYY...                       Y%%%%%%%%%
           [data]  YYYYYYYYYYYYYYYYYYYYYYYYYYYYY...                       Y%%%%%%%%%
           [data]  ......
-                  <--------------------- u-stride / v-stride -------------------->
-                  <------------------ u-width + v-width ----------------->
+                  &lt;--------------------- u-stride / v-stride --------------------&gt;
+                  &lt;------------------ u-width + v-width -----------------&gt;
           [index] 307200(u-offset)                                       307819  307839
                   |------------------------------------------------------|-------|
           [index] |307201(v-offset)                                      |307820 |
@@ -754,14 +902,13 @@
                    ^            ^
                   u-skip        v-skip
         </pre>
-
         <pre class='example highlight'>
           Example4: DEPTH image, width = 640, height = 480, stride = 1280
 
           chanel_d: offset = 0, width = 640, height = 480, data type = uint16, stride = 1280, skip = 0
 
-                  <----------------------- d-stride ---------------------->
-                  <----------------------- d-width ----------------------->
+                  &lt;----------------------- d-stride ----------------------&gt;
+                  &lt;----------------------- d-width -----------------------&gt;
           [index] 012345                                                  1280
                   ||||||--------------------------------------------------|
           [data]  DDDDDDDDDDDDDDDDDDDDDDDDDDDDD...                        D
@@ -769,10 +916,12 @@
           [data]  DDDDDDDDDDDDDDDDDDDDDDDDDDDDD...                        D
           [data]  ......
         </pre>
-
         <section id='imageformatpixellayout-interface'>
-          <h2><code>ImageFormatPixelLayout</code> interface</h2>
-          <dl class="idl" title="[Exposed=(Window,Worker)] interface ChannelPixelLayout">
+          <h2>
+            <code>ImageFormatPixelLayout</code> interface
+          </h2>
+          <dl class="idl" title=
+          "[Exposed=(Window,Worker)] interface ChannelPixelLayout">
             <dt>
               readonly attribute unsigned long offset
             </dt>
@@ -783,27 +932,24 @@
                 method.)
               </p>
             </dd>
-
             <dt>
               readonly attribute unsigned long width
             </dt>
             <dd>
               <p>
-                The width of this channel.
-                <a>Channel</a>s in an image format may have different width.
+                The width of this channel. <a>Channel</a>s in an image format
+                may have different width.
               </p>
             </dd>
-
             <dt>
               readonly attribute unsigned long height
             </dt>
             <dd>
               <p>
-                The height of this channel.
-                <a>Channel</a>s in an image format may have different height.
+                The height of this channel. <a>Channel</a>s in an image format
+                may have different height.
               </p>
             </dd>
-
             <dt>
               readonly attribute DataType dataType
             </dt>
@@ -812,23 +958,18 @@
                 The data type used to store one single <a>pixel value</a>.
               </p>
             </dd>
-
             <dt>
               readonly attribute unsigned long stride
             </dt>
             <dd>
               <p>
                 The stride of this channel.
-              </p>
-              </p>
-                The stride is the number of bytes between the beging two
-                consecutive raws in memory.
-              </p>
+              </p>The stride is the number of bytes between the beging two
+              consecutive raws in memory.
               <p>
                 The total bytes of each raw plus the padding bytes of each raw.
               </p>
             </dd>
-
             <dt>
               readonly attribute unsigned long skip
             </dt>
@@ -839,36 +980,40 @@
               </p>
               <p>
                 Possible values:
-                <ul>
-                  <li>
-                    zero: for <a>planar pixel layout</a>.
-                  </li>
-                  <li>
-                    a positive integer: for <a>interleaving pixel layout</a>.
-                  </li>
-                </ul>
               </p>
+              <ul>
+                <li>zero: for <a>planar pixel layout</a>.
+                </li>
+                <li>a positive integer: for <a>interleaving pixel layout</a>.
+                </li>
+              </ul>
             </dd>
           </dl>
         </section>
         <section id='channelpixellayout-interface'>
-          <h2><code>ChannelPixelLayout</code> interface</h2>
-          <dl class="idl" title="[Exposed=(Window,Worker)] interface ImageFormatPixelLayout">
+          <h2>
+            <code>ChannelPixelLayout</code> interface
+          </h2>
+          <dl class="idl" title=
+          "[Exposed=(Window,Worker)] interface ImageFormatPixelLayout">
             <dt>
               readonly attribute sequence&lt;ChannelPixelLayout&gt; channels
             </dt>
             <dd>
               <p>
-                Channel information of this image format.
-                Each image format has at least one <a>channel</a>.
-              <p>
+                Channel information of this image format. Each image format has
+                at least one <a>channel</a>.
+              </p>
             </dd>
           </dl>
         </section>
       </section>
       <section id='imagebitmap-interface-extensions'>
-        <h2><code>ImageBitmap</code> interface</h2>
-        <dl class="idl" title="[Exposed=(Window,Worker)] partial interface ImageBitmap">
+        <h2>
+          <code>ImageBitmap</code> interface
+        </h2>
+        <dl class="idl" title=
+        "[Exposed=(Window,Worker)] partial interface ImageBitmap">
           <dt>
             ImageFormat findOptimalFormat()
           </dt>
@@ -884,13 +1029,14 @@
               image formats.
             </p>
             <dl class="parameters">
-              <dt>optional sequence&lt;ImageFormat&gt; possibleFormats</dt>
+              <dt>
+                optional sequence&lt;ImageFormat&gt; possibleFormats
+              </dt>
               <dd>
                 A list of image formats that users can handler.
               </dd>
             </dl>
           </dd>
-
           <dt>
             long mappedDataLength()
           </dt>
@@ -907,13 +1053,14 @@
               the given <code>format</code>.
             </p>
             <dl class="parameters">
-              <dt>ImageFormat format</dt>
+              <dt>
+                ImageFormat format
+              </dt>
               <dd>
                 The format that users want.
               </dd>
             </dl>
           </dd>
-
           <dt>
             Promise&lt;ImageFormatPixelLayout&gt; mapDataInto()
           </dt>
@@ -921,9 +1068,9 @@
             <p>
               Makes a copy of the underlying image data in the given format
               <code>format</code> into the given <code>buffer</code> at offset
-              <code>offset</code>, filling at most <code>length</code> bytes and
-              returns an <a>ImageFormatPixelLayout</a> object which describes
-              the pixel layout.
+              <code>offset</code>, filling at most <code>length</code> bytes
+              and returns an <a>ImageFormatPixelLayout</a> object which
+              describes the pixel layout.
             </p>
             <p>
               Throws if <code>format</code> is not supported.
@@ -933,24 +1080,32 @@
               <a>ImageFormatPixelLayout</a> object.
             </p>
             <p>
-              Return an <a>ImageFormatPixelLayout</a> object which describes the
-              pixel layout.
+              Return an <a>ImageFormatPixelLayout</a> object which describes
+              the pixel layout.
             </p>
             <dl class="parameters">
-              <dt>ImageFormat format</dt>
+              <dt>
+                ImageFormat format
+              </dt>
               <dd>
                 The format that users want.
               </dd>
-              <dt>BufferSource buffer</dt>
+              <dt>
+                BufferSource buffer
+              </dt>
               <dd>
                 A container for receiving the mapped image data.
               </dd>
-              <dt>long offset</dt>
+              <dt>
+                long offset
+              </dt>
               <dd>
-                The beginning position of the <code>buffer</code> to place
-                the mapped data.
+                The beginning position of the <code>buffer</code> to place the
+                mapped data.
               </dd>
-              <dt>long length</dt>
+              <dt>
+                long length
+              </dt>
               <dd>
                 The length of space in the <code>buffer</code> that could be
                 filled.
@@ -960,10 +1115,13 @@
         </dl>
       </section>
       <section id='imagebitmapfactories-interface-extensions'>
-        <h2><code>ImageBitmapFactories</code> interface</h2>
-        <dl class="idl" title="[NoInterfaceObject, Exposed=(Window,Worker)] partial interface ImageBitmapFactories">
-          <dt>
-            Promise&lt;ImageBitmap&gt;  createImageBitmap()
+        <h2>
+          <code>ImageBitmapFactories</code> interface
+        </h2>
+        <dl class="idl" title=
+        "[NoInterfaceObject, Exposed=(Window,Worker)] partial interface ImageBitmapFactories">
+        <dt>
+            Promise&lt;ImageBitmap&gt; createImageBitmap()
           </dt>
           <dd>
             <p>
@@ -971,35 +1129,44 @@
               <code>BufferSource</code> containg raw image data.
             </p>
             <dl class="parameters">
-              <dt>BufferSource buffer</dt>
+              <dt>
+                BufferSource buffer
+              </dt>
               <dd>
                 A container of the raw image data.
               </dd>
-              <dt>long offset</dt>
+              <dt>
+                long offset
+              </dt>
               <dd>
                 The beginning position of the <code>buffer</code> where the raw
                 image data is placed.
               </dd>
-              <dt>long length</dt>
+              <dt>
+                long length
+              </dt>
               <dd>
                 The length of spaces in the <code>buffer</code> that the raw
                 image data is palced.
               </dd>
-              <dt>ImageFormat format</dt>
+              <dt>
+                ImageFormat format
+              </dt>
               <dd>
                 The format of the raw image data.
               </dd>
-              <dt>ImageFormatPixelLayout layout</dt>
+              <dt>
+                ImageFormatPixelLayout layout
+              </dt>
               <dd>
-                The pixel layout of the raw image data,
-                which describes how the data is arranged in the given
-                <code>buffer</code> as the given <code>format</code>.
+                The pixel layout of the raw image data, which describes how the
+                data is arranged in the given <code>buffer</code> as the given
+                <code>format</code>.
               </dd>
             </dl>
           </dd>
-
           <dt>
-            Promise&lt;ImageBitmap&gt;  createImageBitmap()
+            Promise&lt;ImageBitmap&gt; createImageBitmap()
           </dt>
           <dd>
             <p>
@@ -1008,92 +1175,109 @@
               cropping area.
             </p>
             <dl class="parameters">
-              <dt>BufferSource buffer</dt>
+              <dt>
+                BufferSource buffer
+              </dt>
               <dd>
                 A container of the raw image data.
               </dd>
-              <dt>long offset</dt>
+              <dt>
+                long offset
+              </dt>
               <dd>
                 The beginning position of the <code>buffer</code> where the raw
                 image data is placed.
               </dd>
-              <dt>long length</dt>
+              <dt>
+                long length
+              </dt>
               <dd>
                 The length of spaces in the <code>buffer</code> that the raw
                 image data is palced.
               </dd>
-              <dt>ImageFormat format</dt>
+              <dt>
+                ImageFormat format
+              </dt>
               <dd>
                 The format of the raw image data.
               </dd>
-              <dt>ImageFormatPixelLayout layout</dt>
+              <dt>
+                ImageFormatPixelLayout layout
+              </dt>
               <dd>
-                The pixel layout of the raw image data,
-                which describes how the data is arranged in the given
-                <code>buffer</code> as the given <code>format</code>.
+                The pixel layout of the raw image data, which describes how the
+                data is arranged in the given <code>buffer</code> as the given
+                <code>format</code>.
               </dd>
-              <dt>long sx</dt>
+              <dt>
+                long sx
+              </dt>
               <dd>
                 The x-coordinate of the starting point of the cropping
                 rectangle.
               </dd>
-              <dt>long sy</dt>
+              <dt>
+                long sy
+              </dt>
               <dd>
                 The y-coordinate of the starting point of the cropping
                 rectangle.
               </dd>
-              <dt>long sw</dt>
+              <dt>
+                long sw
+              </dt>
               <dd>
                 The width of the cropping rectangle.
               </dd>
-              <dt>long sh</dt>
+              <dt>
+                long sh
+              </dt>
               <dd>
                 The height of the cropping rectangle.
               </dd>
             </dl>
           </dd>
         </dl>
-
         <p>
           When the <code>createImageBitmap()</code> is invocked, the User Agent
           MUST run the following steps:
-          <ol>
-            <li>
-              If either the <em>sw</em> or <em>sh</em> arguments are specified
-              but zero,
-              Return a promise rejected with an IndexSizeError exception and
-              abort these steps.
-            </li>
-            <li>
-              If the <em>buffer</em> has been
-              <code><a href="http://www.w3.org/TR/html51/infrastructure.html#concept-transferable-neutered">neutered</a></code>,
-              Return a promise rejected with an InvalidStateError exception and
-              abort these steps.
-            </li>
-            <li>
-              Create a new <code>ImageBitmap</code> object.
-            </li>
-            <li>
-              Let the <code>ImageBitmap</code> object's bitmap data be the image
-              data given by the <code>BufferSource</code> object,
-              <code><a href="http://www.w3.org/TR/html51/webappapis.html#cropped-to-the-source-rectangle">cropped to the source rectangle</a></code>.
-            </li>
-            <li>
-              Return a new <code>Promise</code>, but continue running these steps
-              <code><a href="http://www.w3.org/TR/html51/infrastructure.html#in-parallel">in parallel</a></code>.
-            </li>
-            <li>
-              <code><a href="http://www.w3.org/TR/html51/infrastructure.html#concept-resolver-fulfill">Resolve</a></code>
-              the <code>Promise</code> with the new <code>ImageBitmap</code>
-              object as the value.
-            </li>
-          <ol>
-
         </p>
+        <ol>
+          <li>If either the <em>sw</em> or <em>sh</em> arguments are specified
+          but zero, Return a promise rejected with an IndexSizeError exception
+          and abort these steps.
+          </li>
+          <li>If the <em>buffer</em> has been <code><a href=
+          "http://www.w3.org/TR/html51/infrastructure.html#concept-transferable-neutered">
+            neutered</a></code>, Return a promise rejected with an
+            InvalidStateError exception and abort these steps.
+          </li>
+          <li>Create a new <code>ImageBitmap</code> object.
+          </li>
+          <li>Let the <code>ImageBitmap</code> object's bitmap data be the
+          image data given by the <code>BufferSource</code> object,
+          <code><a href=
+          "http://www.w3.org/TR/html51/webappapis.html#cropped-to-the-source-rectangle">
+            cropped to the source rectangle</a></code>.
+          </li>
+          <li>Return a new <code>Promise</code>, but continue running these
+          steps <code><a href=
+          "http://www.w3.org/TR/html51/infrastructure.html#in-parallel">in
+          parallel</a></code>.
+          </li>
+          <li>
+            <code><a href=
+            "http://www.w3.org/TR/html51/infrastructure.html#concept-resolver-fulfill">
+            Resolve</a></code> the <code>Promise</code> with the new
+            <code>ImageBitmap</code> object as the value.
+          </li>
+        </ol>
       </section>
     </section>
     <section>
-      <h2>Examples</h2>
+      <h2>
+        Examples
+      </h2>
       <h3>
         WorkerMonitor example:
       </h3>
@@ -1101,10 +1285,10 @@
         This example demonstrates how to hook a <code>Worker</code> with a
         <code>MediaStreamTrack</code> and also shows how to use
         <code>postMessage</code> to communicate between main thread and worker
-        thread. In this example, the role of control_worker.js is doing flow control.
-        This script decide whether drop frame or not. If the system is not busy,
-        the script will dispatch current frame to process_worker.js or it just
-        drop the frame.
+        thread. In this example, the role of control_worker.js is doing flow
+        control. This script decide whether drop frame or not. If the system is
+        not busy, the script will dispatch current frame to process_worker.js
+        or it just drop the frame.
       </p>
       <h4>
         Main file javascript
@@ -1215,8 +1399,8 @@
         WorkerMonitor example in multiple workers:
       </h3>
       <p>
-        This example is extended from previous "WorkerMonitor example". The main
-        difference is this example create a WorkerPool object in
+        This example is extended from previous "WorkerMonitor example". The
+        main difference is this example create a WorkerPool object in
         control_worker.js. The script will reuse the workers in the pool. This
         mechanism full utilized the power of multi-core machine to reduce the
         frame drop rate.
@@ -1277,7 +1461,7 @@
         }
 
         WorkerPool.prototype.Init = function(script, numOfWorkers) {
-          for (var i = 0; i < numOfWorkers; ++i) {
+          for (var i = 0; i &lt; numOfWorkers; ++i) {
             this.avaialableQueue.push(new ProcessWorker(i, script, this));
           }
         }
@@ -1289,7 +1473,7 @@
 
         WorkerPool.prototype.Dispatch = function(task) {
           if (task.taskType == ProcessTask.TASK_TYPE) {
-            if (this.avaialableQueue.length > 0) {
+            if (this.avaialableQueue.length &gt; 0) {
               var processWorker = this.avaialableQueue.shift();
               processWorker.worker.postMessage(task);
               this.workingQueue.push(processWorker);
@@ -1306,7 +1490,7 @@
         }
 
         WorkerPool.prototype.Display = function() {
-          while(this.workingQueue.length > 0) {
+          while(this.workingQueue.length &gt; 0) {
             if (!!(this.workingQueue[0].displayTask)) {
               var processWorker = this.workingQueue.shift();
               postMessage(processWorker.displayTask);
@@ -1319,7 +1503,7 @@
         }
 
         WorkerPool.prototype.FindProcessWorker = function(worker) {
-          for (var i = 0; i < this.workingQueue.length; ++i) {
+          for (var i = 0; i &lt; this.workingQueue.length; ++i) {
             if (this.workingQueue[i].worker == worker) {
               return this.workingQueue[i];
             }
@@ -1419,8 +1603,8 @@
       </h3>
       <p>
         This example shows how to process and display the processed
-        <a>MediaStreamTrack</a>. Be careful, the <code>Worker</code> is appended
-        into the new <a>MediaStreamTrack</a>, not original one.
+        <a>MediaStreamTrack</a>. Be careful, the <code>Worker</code> is
+        appended into the new <a>MediaStreamTrack</a>, not original one.
       </p>
       <h4>
         Main file javascript
@@ -1493,8 +1677,8 @@
           }
 
           // convert YUV to Gray or RGBA
-          for (var i = 0; i < bitmap.height; ++i) {
-            for (var j = 0; j < bitmap.width; ++j) {
+          for (var i = 0; i &lt; bitmap.height; ++i) {
+            for (var j = 0; j &lt; bitmap.width; ++j) {
 
               /*
                *  do invert effect
@@ -1517,7 +1701,9 @@
       </pre>
     </section>
     <section class='appendix'>
-      <h2>Acknowledgements</h2>
+      <h2>
+        Acknowledgements
+      </h2>
       <p>
         Thanks to Robert O'Callahan for his idea of this design.
       </p>

--- a/index.html
+++ b/index.html
@@ -214,6 +214,11 @@
         is defined in [[!WEBIDL]]
       </p>
       <p>
+        The <code><a href=
+        "http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">Promise</a></code>
+        object is defined in [[!ECMASCRIPT]].
+      </p>
+      <p>
         The following concepts and interfaces are defined in [[!HTML]]:
       </p>
       <ul>
@@ -231,6 +236,11 @@
           <dfn><a href=
           "https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">
           event handler IDL attribute</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">
+          in parallel</a></dfn>
         </li>
       </ul>
     </section>
@@ -273,8 +283,9 @@
           <dfn data-lt="video monitor event">Video monitor events</dfn>
         </dt>
         <dd>
-          These events are represented by <a>VideoMonitorEvent</a> objects and
-          provide read access to <a>input frame</a> data represented by an
+          These events are represented by <a>VideoMonitorEvent</a> objects that
+          are dispatched at <dfn>video worker monitor</dfn> and provide read
+          access to <a>input frame</a> data represented by an
           <a>ImageBitmap</a> object.
         </dd>
       </dl>
@@ -284,8 +295,9 @@
         </dt>
         <dd>
           These events are represented by <a>VideoProcessorEvent</a> objects
-          and provide read access to <a>input frame</a> data and write access
-          to <a>output frame</a> data represented by <a>ImageBitmap</a> objects
+          that are dispatched at <dfn>video worker processor</dfn> and provide
+          read access to <a>input frame</a> data and write access to <a>output
+          frame</a> data represented by <a>ImageBitmap</a> objects
           respectively.
         </dd>
       </dl>
@@ -521,45 +533,130 @@
         <h2>
           <code>MediaStreamTrack</code> interface
         </h2>
-        <dl class="idl" title="partial interface MediaStreamTrack">
-          <dt>
-            void addVideoMonitor(Worker worker)
-          </dt>
-          <dd>
-            Associate the <code>worker</code> with the
-            <code>MediaStreamTrack</code>. You can add the same
-            <code>worker</code> to any other <code>MediaStreamTrack</code>.
-          </dd>
-          <dt>
-            void removeVideoMonitor(Worker worker)
-          </dt>
-          <dd>
-            Remove a particular <code>Worker</code> from the
-            <code>MediaStreamTrack</code>. User Agent should throw exception
-            when the <code>Worker</code> is not exist in the
-            <code>MediaStreamTrack</code>.
-          </dd>
-          <dt>
-            MediaStreamTrack addVideoProcessor(Worker worker)
-          </dt>
-          <dd>
-            This method will create a new <code>MediaStreamTrack</code> and
-            take the original <code>MediaStreamTrack</code> as the input
-            source. Then associate the <code>Worker</code> with new created
-            <code>MediaStreamTrack</code>. The developers can build a processed
-            pipeline by this method.
-          </dd>
-          <dt>
-            void removeVideoProcessor()
-          </dt>
-          <dd>
-            Remove the added <code>Worker</code> from current
-            <code>MediaStreamTrack</code>. User Agent should throw exception
-            when the <code>Worker</code> is not exist in the
-            <code>MediaStreamTrack</code>. A <code>MediaStreamTrack</code> owns
-            at most one Worker processor in any time.
-          </dd>
-        </dl>
+        <pre class="idl">
+          partial interface MediaStreamTrack {
+              Promise&lt;void&gt;             addVideoMonitor(Worker worker);
+              Promise&lt;void&gt;             removeVideoMonitor(Worker worker);
+              Promise&lt;MediaStreamTrack&gt; addVideoProcessor(Worker worker);
+              Promise&lt;void&gt;             removeVideoProcessor();
+          };
+        </pre>
+        <div dfn-for="MediaStreamTrack">
+          <p>
+            The <code><dfn>addVideoMonitor</dfn>()</code> method, when invoked,
+            must run these steps:
+          </p>
+          <ol>
+            <li>Let <var>promise</var> be a new promise.
+            </li>
+            <li>Run these substeps <a>in parallel</a>:
+              <ol>
+                <li>Let <var>worker</var> be the first method argument.
+                </li>
+                <li>Let <var>track</var> be the <a>MediaStreamTrack</a> object
+                on which the method was invoked. (This is the <a>input media
+                stream track</a>.)
+                </li>
+                <li>Associate <var>worker</var> with <var>track</var>.
+                </li>
+                <li>Resolve <var>promise</var> with undefined.
+                </li>
+              </ol>
+            </li>
+            <li>Return <var>promise</var>.
+            </li><!-- TODO: when do we want to reject the promise? -->
+          </ol>
+          <p>
+            The <code><dfn>removeVideoMonitor</dfn>()</code> method, when
+            invoked, must run these steps:
+          </p>
+          <ol>
+            <li>Let <var>promise</var> be a new promise.
+            </li>
+            <li>Run these substeps <a>in parallel</a>:
+              <ol>
+                <li>Let <var>worker</var> be the first method argument.
+                </li>
+                <li>Let <var>track</var> be the <a>MediaStreamTrack</a> object
+                on which the method was invoked.
+                </li>
+                <li>If there exists an association between <var>worker</var>
+                and <var>track</var>, break that association and resolve <var>
+                  promise</var> with undefined.
+                </li>
+                <li>Otherwise, reject <var>promise</var> with
+                <code>NotFoundError</code>.
+                </li>
+              </ol>
+            </li>
+            <li>Return <var>promise</var>.
+            </li>
+          </ol>
+          <p>
+            The <code><dfn>addVideoProcessor</dfn>()</code> method, when
+            invoked, must run these steps:
+          </p>
+          <ol>
+            <li>Let <var>promise</var> be a new promise.
+            </li>
+            <li>Run these substeps <a>in parallel</a>:
+              <ol>
+                <li>Let <var>worker</var> be the first method argument.
+                </li>
+                <li>Let <var>track</var> be the <a>MediaStreamTrack</a> object
+                on which the method was invoked.
+                </li>
+                <li>If there exists an association between <var>worker</var>
+                and <var>track</var>, reject promise with
+                <code>QuotaExceededError</code>.
+                  <div class="note">
+                    A <a>MediaStreamTrack</a> owns at most one <a>video worker
+                    processor</a> at a time.
+                  </div>
+                </li>
+                <li>Associate <var>worker</var> with <var>track</var>.
+                </li>
+                <li>Let <var>new track</var> be a newly created
+                <a>MediaStreamTrack</a> object. (This is the <a>input media
+                stream track</a>.)
+                </li>
+                <li>Associate <var>new track</var> as the <a>output media
+                stream track</a> for <var>worker</var>.
+                </li>
+                <li>Resolve <var>promise</var> with <var>new track</var>.
+                </li>
+              </ol>
+            </li>
+            <li>Return <var>promise</var>.
+            </li>
+          </ol>
+          <p>
+            The <code><dfn>removeVideoProcessor</dfn>()</code> method, when
+            invoked, must run these steps:
+          </p>
+          <ol>
+            <li>Let <var>promise</var> be a new promise.
+            </li>
+            <li>Run these substeps <a>in parallel</a>:
+              <ol>
+                <li>Let <var>worker</var> be the first method argument.
+                </li>
+                <li>Let <var>track</var> be the <a>MediaStreamTrack</a> object
+                on which the method was invoked.
+                </li>
+                <li>If there exists an association between <var>worker</var>
+                and <var>track</var>, break that association and resolve <var>
+                  promise</var> with undefined.
+                </li>
+                <li>Otherwise, reject <var>promise</var> with
+                <code>NotFoundError</code>.
+                </li>
+              </ol>
+            </li>
+            <li>Return <var>promise</var>.
+            </li>
+          </ol>
+        </div>
       </section>
     </section>
     <section id='imagebitmap-extensions'>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
           // This is important for Rec-track documents, do not copy a patent URI from a random
           // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
           // Team Contact.
-          wgPatentURI:  "",
+          wgPatentURI:  ["", ""],
           // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
       };
     </script>
@@ -195,7 +195,7 @@
       <p>
         The <code><a href=
         "http://www.w3.org/TR/WebIDL-1/#common-BufferSource">
-        <dfn>BufferSource</dfn></a></code> is defined in [[!WebIDL]]
+        <dfn>BufferSource</dfn></a></code> is defined in [[!WEBIDL]]
       </p>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -254,6 +254,11 @@
           <var>w</var> as an argument.
         </dd>
       </dl>
+      <p>
+        There are two kinds of <dfn data-lt="video worker event">video worker
+        events</dfn>: <a data-lt="video monitor event">video monitor events</a>
+        and <a data-lt="video processor event">video processor events</a>.
+      </p>
     </section>
     <section>
       <h2>
@@ -317,6 +322,54 @@
             </tbody>
           </table>
         </div>
+        <section>
+          <h2>
+            Video worker event firing
+          </h2>
+          <p>
+            To <dfn>fire a video worker event</dfn> named <var>e</var>, the
+            user agent must run the following steps:
+          </p>
+          <ol>
+            <li link-for="VideoMonitorEvent">If <var>e</var> is
+            <a>videomonitor</a>, create a <a>VideoMonitorEvent</a>, initialize
+            it to have a given name <var>e</var>, to not bubble, to not be
+            cancelable.
+            </li>
+            <li link-for="VideoProcessorEvent">If <var>e</var> is
+            <a>videoprocess</a>, create a <a>VideoProcessorEvent</a>,
+            initialize it to have a given name <var>e</var>, to not bubble, to
+            not be cancelable.
+            </li>
+            <li link-for="VideoMonitorEvent">Initialize the <a>trackId</a>
+            attribute to the value of the <code>id</code> attribute of the <a>
+              video worker source</a>.
+            </li><!-- TODO -->
+            <li link-for="VideoMonitorEvent">Initialize the <a>playbackTime</a>
+            attribute to the value of the <code>currentTime</code> attribute of
+            the <a>MediaStream</a> that contains the <a>video worker
+            source</a>.
+            </li>
+            <li link-for="VideoMonitorEvent">Initialize the
+            <a>inputImageBitmap</a> attribute to the bitmap data of the
+            <a>video worker source</a>'s video frame at the current stream
+            position at <a>playbackTime</a>.
+            </li>
+            <li>
+              <!-- TODO: clarify the definition of targets -->
+              Let <var>associated video workers</var> be the list of
+              <a data-lt="video worker">video workers</a> that share the same
+              <a>video worker source</a>.
+            </li>
+            <li>If <var>e</var> is <a>videomonitor</a>, dispatch the newly
+            created <a>VideoMonitorEvent</a> object at each <var>target</var>.
+            </li>
+            <li>If <var>e</var> is <a>videoprocess</a>, initialize the
+            <a>outputImageBitmap</a> attribute to null, and dispatch the newly
+            created <a>VideoProceeEvent</a> object at each <var>target</var>.
+            </li>
+          </ol>
+        </section>
       </section>
       <section>
         <h2>
@@ -360,32 +413,12 @@
             be initialized to null. It represents the <a>ImageBitmap</a> object
             whose bitmap data is provided by the <a>video monitor source</a>.
           </p>
-          <p>
-            When a user agent is required to <dfn>fire a video worker
-            event</dfn> named <var>e</var>, it must run the following steps:
-          </p>
         </div>
-        <ol link-for="VideoMonitorEvent">
-          <li>Create a <a>VideoMonitorEvent</a>, initialize it to have a name
-          <a>videoprocess</a>, to not bubble, to not be cancelable.
-          </li>
-          <li>Initialize the <a>trackId</a> attribute to the value of the
-          <code>id</code> attribute of the <a>video monitor source</a>.
-          </li><!-- TODO -->
-          <li>Initialize the <a>playbackTime</a> attribute to the value of the
-          <code>currentTime</code> attribute of the <a>MediaStream</a> that
-          contains the <a>video monitor source</a>.
-          </li>
-          <li>Initialize the <a>inputImageBitmap</a> attribute to the bitmap
-          data of the <a>video monitor source</a>'s video frame at the current
-          stream position at <a>playbackTime</a>.
-          </li>
-          <li>Dispatch the newly created <a>VideoMonitorEvent</a> object at the
-          <a>DedicatedWorkerGlobalScope</a> of the <a data-lt=
-          "video worker">video workers</a> that share the same <a>video worker
-          source</a>.
-          </li>
-        </ol>
+        <p>
+          When a user agent is required to <dfn>fire a video monitor
+          event</dfn>, it must <a>fire a video worker event</a> named
+          <a>videomonitor</a>.
+        </p>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -239,10 +239,10 @@
         Terminology
       </h2>
       <p>
-        A <dfn>video worker</dfn> takes an <a>input frame</a> from an
-        <dfn>input media stream track</dfn> and processes an <a>output
-        frame</a> that acts as the <a>source</a> for the <a>output media stream
-        track</a>.
+        A <dfn>video worker</dfn> captures an <a>input frame</a> from an
+        <dfn>input media stream track</dfn> and processes the provided
+        <a>output frame</a> for use as the <a>source</a> for the <a>output
+        media stream track</a>.
       </p>
       <p>
         An <dfn>input frame</dfn> for a worker <var>w</var> is an
@@ -268,16 +268,27 @@
         There are two kinds of <dfn data-lt="video worker event">video worker
         events</dfn>:
       </p>
-      <ul>
-        <li>
-          <a data-lt="video monitor event">Video monitor events</a> represent
-          the <a>input frame</a> only.
-        </li>
-        <li>
-          <a data-lt="video processor event">Video processor events</a>
-          represent the <a>input frame</a> and <a>output frame</a>.
-        </li>
-      </ul>
+      <dl>
+        <dt>
+          <dfn data-lt="video monitor event">Video monitor events</dfn>
+        </dt>
+        <dd>
+          These events are represented by <a>VideoMonitorEvent</a> objects and
+          provide read access to <a>input frame</a> data represented by an
+          <a>ImageBitmap</a> object.
+        </dd>
+      </dl>
+      <dl>
+        <dt>
+          <dfn data-lt="video processor event">Video processor events</dfn>
+        </dt>
+        <dd>
+          These events are represented by <a>VideoProcessorEvent</a> objects
+          and provide read access to <a>input frame</a> data and write access
+          to <a>output frame</a> data represented by <a>ImageBitmap</a> objects
+          respectively.
+        </dd>
+      </dl>
     </section>
     <section>
       <h2>
@@ -397,8 +408,8 @@
           <code id="event-videomonitorevent">VideoMonitorEvent</code> interface
         </h2>
         <p link-for="VideoMonitorEvent">
-          The <dfn>video monitor event</dfn> contains an <a>input frame</a> and
-          its metadata originating from the <a>input media stream track</a>. It
+          The <a>video monitor event</a> contains an <a>input frame</a> and its
+          metadata originating from the <a>input media stream track</a>. It
           uses the <a>VideoMonitorEvent</a> interface for its
           <a>videomonitor</a> events:
         </p>
@@ -450,8 +461,8 @@
           interface
         </h2>
         <p link-for="VideoProcessorEvent">
-          The <dfn>video processor event</dfn> inherits from the <a>video
-          monitor event</a>, and in addition provides means to programmatically
+          The <a>video processor event</a> inherits from the <a>video monitor
+          event</a>, and in addition provides means to programmatically
           construct an <a>output frame</a> for the <a>output media stream
           track</a>. It uses the <a>VideoProcessorEvent</a> interface for its
           <a>videoprocess</a> events:


### PR DESCRIPTION
This PR updates the following sections to use Contiguous IDL (Fixes #16) and adapts the prose accordingly:
- DedicatedWorkerGlobalScope interface
- VideoMonitorEvent interface
- VideoProcessorEvent interface

This PR also proposes a normative change to Fix #18, introduces a Terminology section, and does various editorial fixes. I used tidy-html5 to tidy the document, so in that particular commit you see a lot of indentation changes. I used the following config for tidy:

```
  char-encoding: utf8
  indent: yes
  wrap: 80
  tidy-mark: no
```

@ChiahungTai @kakukogou Please take a look. I can do a similar editorial pass on the rest of the specification if you like this style.
