### PR TITLE
Convert ImageBitmap extensions to use Contiguous IDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,229 +799,263 @@
               We need to elaborate this list for standardization.
             </p>
           </div>
-          <dl id="enum-basic" class="idl" title="enum ImageFormat">
-            <dt>
-              RGBA32
-            </dt>
-            <dd>
-              <p>
-                Channel order: R, G, B, A
-              </p>
-              <p>
-                Channel size: full rgba-chennels
-              </p>
-              <p>
-                Pixel layout: interleaving rgba-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              BGRA32
-            </dt>
-            <dd>
-              <p>
-                Channel order: B, G, R, A
-              </p>
-              <p>
-                Channel size: full bgra-channels
-              </p>
-              <p>
-                Pixel layout: interleaving bgra-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              RGB24
-            </dt>
-            <dd>
-              <p>
-                Channel order: R, G, B
-              </p>
-              <p>
-                Channel size: full rgb-channels
-              </p>
-              <p>
-                Pixel layout: interleaving rgb-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              BGR24
-            </dt>
-            <dd>
-              <p>
-                Channel order: B, G, R
-              </p>
-              <p>
-                Channel size: full bgr-channels
-              </p>
-              <p>
-                Pixel layout: interleaving bgr-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              GRAY8
-            </dt>
-            <dd>
-              <p>
-                Channel order: GRAY
-              </p>
-              <p>
-                Channel size: full gray-channel
-              </p>
-              <p>
-                Pixel layout: planar gray-channel
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              YUV444P
-            </dt>
-            <dd>
-              <p>
-                Channel order: Y, U, V
-              </p>
-              <p>
-                Channel size: full yuv-channels
-              </p>
-              <p>
-                Pixel layout: planar yuv-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              YUV422P
-            </dt>
-            <dd>
-              <p>
-                Channel order: Y, U, V
-              </p>
-              <p>
-                Channel size: full y-channel, half uv-channels
-              </p>
-              <p>
-                Pixel layout: planar yuv-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              YUV420P
-            </dt>
-            <dd>
-              <p>
-                Channel order: Y, U, V
-              </p>
-              <p>
-                Channel size: full y-channel, quarter uv-channels
-              </p>
-              <p>
-                Pixel layout: planar yuv-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              YUV420SP_NV12
-            </dt>
-            <dd>
-              <p>
-                Channel order: Y, U, V
-              </p>
-              <p>
-                Channel size: full y-channel, quarter uv-channels
-              </p>
-              <p>
-                Pixel layout: planar y-channel, interleaving uv-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              YUV420SP_NV21
-            </dt>
-            <dd>
-              <p>
-                Channel order: Y, V, U
-              </p>
-              <p>
-                Channel size: full y-channel, quarter uv-channels
-              </p>
-              <p>
-                Pixel layout: planar y-channel, interleaving vu-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              HSV
-            </dt>
-            <dd>
-              <p>
-                Channel order: H, S, V
-              </p>
-              <p>
-                Channel size: full hsv-channels
-              </p>
-              <p>
-                Pixel layout: interleaving hsv-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              Lab
-            </dt>
-            <dd>
-              <p>
-                Channel order: l, a, b
-              </p>
-              <p>
-                Channel size: full lab-channels
-              </p>
-              <p>
-                Pixel layout: interleaving lab-channels
-              </p>
-              <p>
-                Data type: 8-bit unsigned integer
-              </p>
-            </dd>
-            <dt>
-              DEPTH
-            </dt>
-            <dd>
-              <p>
-                Channel order: DEPTH
-              </p>
-              <p>
-                Channel size: full depth-channel
-              </p>
-              <p>
-                Pixel layout: planar depth-channel
-              </p>
-              <p>
-                Data type: 16-bit unsigned integer
-              </p>
-            </dd>
-          </dl>
+          <pre class="idl">
+            enum ImageFormat {
+                "RGBA32",
+                "BGRA32",
+                "RGB24",
+                "BGR24",
+                "GRAY8",
+                "YUV444P",
+                "YUV422P",
+                "YUV420P",
+                "YUV420SP_NV12",
+                "YUV420SP_NV21",
+                "HSV",
+                "Lab",
+                "DEPTH"
+            };
+          </pre>
+          <table class="simple">
+            <tr>
+              <th>
+                ImageFormat
+              </th>
+              <th>
+                Channel order
+              </th>
+              <th>
+                Channel size
+              </th>
+              <th>
+                Pixel layout
+              </th>
+              <th>
+                Data type
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>RGBA32</dfn></code>
+              </td>
+              <td>
+                R, G, B, A
+              </td>
+              <td>
+                full rgba-channels
+              </td>
+              <td>
+                interleaving rgba-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>BGRA32</dfn></code>
+              </td>
+              <td>
+                B, G, R, A
+              </td>
+              <td>
+                full bgra-channels
+              </td>
+              <td>
+                interleaving bgra-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>RGB24</dfn></code>
+              </td>
+              <td>
+                R, G, B
+              </td>
+              <td>
+                full rgb-channels
+              </td>
+              <td>
+                interleaving rgb-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>BGR24</dfn></code>
+              </td>
+              <td>
+                B, G, R
+              </td>
+              <td>
+                full bgr-channels
+              </td>
+              <td>
+                interleaving bgr-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>GRAY8</dfn></code>
+              </td>
+              <td>
+                GRAY
+              </td>
+              <td>
+                full gray-channel
+              </td>
+              <td>
+                planar gray-channel
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>YUV444P</dfn></code>
+              </td>
+              <td>
+                Y, U, V
+              </td>
+              <td>
+                full yuv-channels
+              </td>
+              <td>
+                planar yuv-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>YUV422P</dfn></code>
+              </td>
+              <td>
+                Y, U, V
+              </td>
+              <td>
+                full y-channel, half uv-channels
+              </td>
+              <td>
+                planar yuv-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>YUV420P</dfn></code>
+              </td>
+              <td>
+                Y, U, V
+              </td>
+              <td>
+                full y-channel, quarter uv-channels
+              </td>
+              <td>
+                planar yuv-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>YUV420SP_NV12</dfn></code>
+              </td>
+              <td>
+                Y, U, V
+              </td>
+              <td>
+                full y-channel, quarter uv-channels
+              </td>
+              <td>
+                planar y-channel, interleaving uv-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>YUV420SP_NV21</dfn></code>
+              </td>
+              <td>
+                Y, V, U
+              </td>
+              <td>
+                full y-channel, quarter uv-channels
+              </td>
+              <td>
+                planar y-channel, interleaving vu-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>HSV</dfn></code>
+              </td>
+              <td>
+                H, S, V
+              </td>
+              <td>
+                full hsv-channels
+              </td>
+              <td>
+                interleaving hsv-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>Lab</dfn></code>
+              </td>
+              <td>
+                l, a, b
+              </td>
+              <td>
+                full lab-channels
+              </td>
+              <td>
+                interleaving lab-channels
+              </td>
+              <td>
+                8-bit unsigned integer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><dfn>DEPTH</dfn></code>
+              </td>
+              <td>
+                DEPTH
+              </td>
+              <td>
+                full depth-channel
+              </td>
+              <td>
+                planar depth-channel
+              </td>
+              <td>
+                16-bit unsigned integer
+              </td>
+            </tr>
+          </table>
         </section>
         <section id='datatype-enumeration'>
           <h2>
@@ -1031,56 +1065,92 @@
             An enumeration <a>DataType</a> defines a list of data types that is
             used to store a single <a>pixel value</a>.
           </p>
-          <dl id="enum-basic" class="idl" title="enum DataType">
-            <dt>
-              uint8
-            </dt>
-            <dd>
-              8-bit unsigned integer.
-            </dd>
-            <dt>
-              int8
-            </dt>
-            <dd>
-              8-bit integer.
-            </dd>
-            <dt>
-              uint16
-            </dt>
-            <dd>
-              16-bit unsigned integer.
-            </dd>
-            <dt>
-              int16
-            </dt>
-            <dd>
-              16-bit integer.
-            </dd>
-            <dt>
-              uint32
-            </dt>
-            <dd>
-              32-bit unsigned integer.
-            </dd>
-            <dt>
-              int32
-            </dt>
-            <dd>
-              32-bit integer.
-            </dd>
-            <dt>
-              float32
-            </dt>
-            <dd>
-              32-bit IEEE floating point number.
-            </dd>
-            <dt>
-              float64
-            </dt>
-            <dd>
-              64-bit IEEE floating point number.
-            </dd>
-          </dl>
+          <pre class="idl">
+            enum DataType {
+                "uint8",
+                "int8",
+                "uint16",
+                "int16",
+                "uint32",
+                "int32",
+                "float32",
+                "float64"
+            };
+          </pre>
+          <table class="simple">
+            <tr>
+              <th>
+                DataType
+              </th>
+              <th>
+                description
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <code><a>uint8</a></code>
+              </td>
+              <td>
+                8-bit unsigned integer.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><a>int8</a></code>
+              </td>
+              <td>
+                8-bit integer.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><a>uint16</a></code>
+              </td>
+              <td>
+                16-bit unsigned integer.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><a>int16</a></code>
+              </td>
+              <td>
+                16-bit integer.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><a>uint32</a></code>
+              </td>
+              <td>
+                32-bit unsigned integer.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><a>int32</a></code>
+              </td>
+              <td>
+                32-bit integer.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><a>float32</a></code>
+              </td>
+              <td>
+                32-bit IEEE floating point number.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code><a>float64</a></code>
+              </td>
+              <td>
+                64-bit IEEE floating point number.
+              </td>
+            </tr>
+          </table>
         </section>
       </section>
       <section id='pixellayout'>

--- a/index.html
+++ b/index.html
@@ -242,6 +242,15 @@
           "https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">
           in parallel</a></dfn>
         </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/#cropped-to-the-source-rectangle">cropped
+          to the source rectangle</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/#concept-transferable-neutered">neutered</a></dfn>
+        </li>
       </ul>
     </section>
     <section>
@@ -1506,160 +1515,61 @@
         <h2>
           <code>ImageBitmapFactories</code> interface
         </h2>
-        <dl class="idl" title=
-        "[NoInterfaceObject, Exposed=(Window,Worker)] partial interface ImageBitmapFactories">
-        <dt>
-            Promise&lt;ImageBitmap&gt; createImageBitmap()
-          </dt>
-          <dd>
-            <p>
-              Create an <code>ImageBitmap</code> from a
-              <code>BufferSource</code> containg raw image data.
-            </p>
-            <dl class="parameters">
-              <dt>
-                BufferSource buffer
-              </dt>
-              <dd>
-                A container of the raw image data.
-              </dd>
-              <dt>
-                long offset
-              </dt>
-              <dd>
-                The beginning position of the <code>buffer</code> where the raw
-                image data is placed.
-              </dd>
-              <dt>
-                long length
-              </dt>
-              <dd>
-                The length of spaces in the <code>buffer</code> that the raw
-                image data is palced.
-              </dd>
-              <dt>
-                ImageFormat format
-              </dt>
-              <dd>
-                The format of the raw image data.
-              </dd>
-              <dt>
-                ImageFormatPixelLayout layout
-              </dt>
-              <dd>
-                The pixel layout of the raw image data, which describes how the
-                data is arranged in the given <code>buffer</code> as the given
-                <code>format</code>.
-              </dd>
-            </dl>
-          </dd>
-          <dt>
-            Promise&lt;ImageBitmap&gt; createImageBitmap()
-          </dt>
-          <dd>
-            <p>
-              Create an <code>ImageBitmap</code> from a
-              <code>BufferSource</code> containg raw image data with a given
-              cropping area.
-            </p>
-            <dl class="parameters">
-              <dt>
-                BufferSource buffer
-              </dt>
-              <dd>
-                A container of the raw image data.
-              </dd>
-              <dt>
-                long offset
-              </dt>
-              <dd>
-                The beginning position of the <code>buffer</code> where the raw
-                image data is placed.
-              </dd>
-              <dt>
-                long length
-              </dt>
-              <dd>
-                The length of spaces in the <code>buffer</code> that the raw
-                image data is palced.
-              </dd>
-              <dt>
-                ImageFormat format
-              </dt>
-              <dd>
-                The format of the raw image data.
-              </dd>
-              <dt>
-                ImageFormatPixelLayout layout
-              </dt>
-              <dd>
-                The pixel layout of the raw image data, which describes how the
-                data is arranged in the given <code>buffer</code> as the given
-                <code>format</code>.
-              </dd>
-              <dt>
-                long sx
-              </dt>
-              <dd>
-                The x-coordinate of the starting point of the cropping
-                rectangle.
-              </dd>
-              <dt>
-                long sy
-              </dt>
-              <dd>
-                The y-coordinate of the starting point of the cropping
-                rectangle.
-              </dd>
-              <dt>
-                long sw
-              </dt>
-              <dd>
-                The width of the cropping rectangle.
-              </dd>
-              <dt>
-                long sh
-              </dt>
-              <dd>
-                The height of the cropping rectangle.
-              </dd>
-            </dl>
-          </dd>
-        </dl>
-        <p>
-          When the <code>createImageBitmap()</code> is invocked, the User Agent
-          MUST run the following steps:
-        </p>
-        <ol>
-          <li>If either the <em>sw</em> or <em>sh</em> arguments are specified
-          but zero, Return a promise rejected with an IndexSizeError exception
-          and abort these steps.
-          </li>
-          <li>If the <em>buffer</em> has been <code><a href=
-          "http://www.w3.org/TR/html51/infrastructure.html#concept-transferable-neutered">
-            neutered</a></code>, Return a promise rejected with an
-            InvalidStateError exception and abort these steps.
-          </li>
-          <li>Create a new <code>ImageBitmap</code> object.
-          </li>
-          <li>Let the <code>ImageBitmap</code> object's bitmap data be the
-          image data given by the <code>BufferSource</code> object,
-          <code><a href=
-          "http://www.w3.org/TR/html51/webappapis.html#cropped-to-the-source-rectangle">
-            cropped to the source rectangle</a></code>.
-          </li>
-          <li>Return a new <code>Promise</code>, but continue running these
-          steps <code><a href=
-          "http://www.w3.org/TR/html51/infrastructure.html#in-parallel">in
-          parallel</a></code>.
-          </li>
-          <li>
-            <code><a href=
-            "http://www.w3.org/TR/html51/infrastructure.html#concept-resolver-fulfill">
-            Resolve</a></code> the <code>Promise</code> with the new
-            <code>ImageBitmap</code> object as the value.
-          </li>
-        </ol>
+        <pre class="idl">
+          [NoInterfaceObject, Exposed=(Window,Worker)]
+          partial interface ImageBitmapFactories {
+              Promise&lt;ImageBitmap&gt; createImageBitmap (BufferSource buffer, long offset, long length, ImageFormat format, ImageFormatPixelLayout layout);
+              Promise&lt;ImageBitmap&gt; createImageBitmap (BufferSource buffer, long offset, long length, ImageFormat format, ImageFormatPixelLayout layout, long sx, long sy, long sw, long sh);
+          };
+        </pre>
+        <div dfn-for="ImageBitmapFactories">
+          <p>
+            The <code><dfn>createImageBitmap</dfn>(buffer, offset, length,
+            format, layout, sx, sy, sw, sh)</code> method must run the
+            following steps:
+          </p>
+          <ol>
+            <li>Let <var>buffer</var> be the container for the raw image data.
+            </li>
+            <li>Let <var>offset</var> be the <a>offset</a> (beginning position)
+            of <var>buffer</var>.
+            </li>
+            <li>Let <var>length</var> be the length of spaces in
+            <var>buffer</var> in which the raw image data is placed into.
+            </li>
+            <li>Let <var>format</var> be the the <a>image format</a> of the raw
+            image data placed in <var>buffer</var>.
+            </li>
+            <li>Let <var>layout</var> be the <a>pixel layout</a> for the raw
+            image data, which describes how the data is arranged in
+            <var>buffer</var> using <var>format</var>.
+            </li>
+            <!-- TODO: do we want to special-case sx, sy handling if undefined? -->
+            <!-- sx - The x-coordinate of the starting point of the cropping rectangle. -->
+            <!-- sy - The y-coordinate of the starting point of the cropping rectangle. -->
+            <li>If either the <em>sw</em> or <em>sh</em> arguments are
+            specified but zero, return <var>promise</var> rejected with an
+            <code>IndexSizeError</code> and terminate these steps.
+            </li>
+            <li>If <var>buffer</var> has been <a>neutered</a>, reject
+            <var>promise</var> with <code>InvalidStateError</code> and
+            terminate these steps.
+            </li>
+            <li>Let <var>image bitmap</var> be a newly created
+            <code>ImageBitmap</code> object.
+            </li>
+            <li>Set <var>image bitmap</var>'s bitmap data to the image data
+            given by the <code>BufferSource</code> <var>buffer</var>,
+            <a>cropped to the source rectangle</a>.
+            </li>
+            <li>Return a new <var>promise</var>, but continue running these
+            steps <a>in parallel</a>.
+            </li>
+            <li>Resolve <var>promise</var> with the new <a>ImageBitmap</a>
+            object as the value.
+            </li>
+          </ol>
+        </div>
       </section>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -835,9 +835,10 @@
                 "YUV420SP_NV21",
                 "HSV",
                 "Lab",
-                "DEPTH"
+                "DEPTH",
+                /* empty string */ ""
             };
-          </pre>
+          </pre>N/A N/A
           <table class="simple" dfn-for="ImageFormat">
             <tr>
               <th>
@@ -1077,6 +1078,23 @@
                 16-bit unsigned integer
               </td>
             </tr>
+            <tr>
+              <td>
+                <code>""</code> (<dfn>the empty string</dfn>)
+              </td>
+              <td>
+                N/A
+              </td>
+              <td>
+                N/A
+              </td>
+              <td>
+                N/A
+              </td>
+              <td>
+                N/A
+              </td>
+            </tr>
           </table>
         </section>
         <section id='datatype-enumeration'>
@@ -1200,7 +1218,7 @@
           "pixel value">pixel values</a> are arranged in the one dimensional
           array buffer.
         </p>
-        <p>
+        <p link-for="ImageBitmap">
           A <a>channel</a> has an associated <dfn>offset</dfn> that denotes the
           beginning position of the <a>channel</a>'s data relative to the given
           <a>BufferSource</a> parameter of the
@@ -1389,107 +1407,100 @@
         <h2>
           <code>ImageBitmap</code> interface
         </h2>
-        <dl class="idl" title=
-        "[Exposed=(Window,Worker)] partial interface ImageBitmap">
-          <dt>
-            ImageFormat findOptimalFormat()
-          </dt>
-          <dd>
-            <p>
-              Find the best image format for receiving data.
-            </p>
-            <p>
-              Return one of the <code>possibleFormats</code> or the empty
-              string if no any format in the list is supported. If the
-              <code>possibleFormats</code> is not given, then returns the most
-              suitable image format for this ImageBitmap from all supported
-              image formats.
-            </p>
-            <dl class="parameters">
-              <dt>
-                optional sequence&lt;ImageFormat&gt; possibleFormats
-              </dt>
-              <dd>
-                A list of image formats that users can handler.
-              </dd>
-            </dl>
-          </dd>
-          <dt>
-            long mappedDataLength()
-          </dt>
-          <dd>
-            <p>
-              Calculate the length of mapped data wile the image is represented
-              in the given <code>format</code>.
-            </p>
-            <p>
-              Throws if <code>format</code> is not supported.
-            </p>
-            <p>
-              Return the length (in bytes) of image data that is represented in
-              the given <code>format</code>.
-            </p>
-            <dl class="parameters">
-              <dt>
-                ImageFormat format
-              </dt>
-              <dd>
-                The format that users want.
-              </dd>
-            </dl>
-          </dd>
-          <dt>
-            Promise&lt;ImageFormatPixelLayout&gt; mapDataInto()
-          </dt>
-          <dd>
-            <p>
-              Makes a copy of the underlying image data in the given format
-              <code>format</code> into the given <code>buffer</code> at offset
-              <code>offset</code>, filling at most <code>length</code> bytes
-              and returns an <a>ImageFormatPixelLayout</a> object which
-              describes the pixel layout.
-            </p>
-            <p>
-              Throws if <code>format</code> is not supported.
-            </p>
-            <p>
-              Each time this method is invoked returns a new
-              <a>ImageFormatPixelLayout</a> object.
-            </p>
-            <p>
-              Return an <a>ImageFormatPixelLayout</a> object which describes
-              the pixel layout.
-            </p>
-            <dl class="parameters">
-              <dt>
-                ImageFormat format
-              </dt>
-              <dd>
-                The format that users want.
-              </dd>
-              <dt>
-                BufferSource buffer
-              </dt>
-              <dd>
-                A container for receiving the mapped image data.
-              </dd>
-              <dt>
-                long offset
-              </dt>
-              <dd>
-                The beginning position of the <code>buffer</code> to place the
-                mapped data.
-              </dd>
-              <dt>
-                long length
-              </dt>
-              <dd>
-                The length of space in the <code>buffer</code> that could be
-                filled.
-              </dd>
-            </dl>
-          </dd>
-        </dl>
+        <pre class="idl">
+          [Exposed=(Window,Worker)]
+          partial interface ImageBitmap {
+              ImageFormat                     findOptimalFormat (optional sequence&lt;ImageFormat&gt; possibleFormats);
+              long                            mappedDataLength (ImageFormat format);
+              Promise&lt;ImageFormatPixelLayout&gt; mapDataInto (ImageFormat format, BufferSource buffer, long offset, long length);
+          };
+        </pre>
+        <div dfn-for="ImageBitmap">
+          <p>
+            The <code><dfn>findOptimalFormat</dfn>(possibleFormats)</code>
+            method must run the following steps:
+          </p>
+          <ol>
+            <li>Let <var>image bitmap</var> be the object on which the method
+            was invoked.
+            </li>
+            <li>Let <var>possible formats</var> be the first argument.
+            </li>
+            <li>If <var>possible formats</var> is empty, return
+            <a>ImageFormat</a> that is <dfn>the most suitable image
+            format</dfn> for <var>image bitmap</var>, and terminate these
+            steps.
+              <div class="note">
+                It is up to the implementation to decide how to choose <a>the
+                most suitable image format</a> from a list of image formats.
+              </div>
+            </li>
+            <li>If none of the <a data-lt="image format">image formats</a> in
+            <var>possible formats</var> is an <a>image format</a> that the user
+            agent knows it can render, return <a>the empty string</a> and
+            terminate these steps.
+            </li>
+            <li>Otherwise, return <a>ImageFormat</a> that is <a>the most
+            suitable image format</a> out of <var>possible formats</var> for
+            <var>image bitmap</var>, and terminate these steps.
+            </li>
+          </ol>
+          <p>
+            The <code><dfn>mappedDataLength</dfn>(format)</code> method must
+            run the following steps:
+          </p>
+          <ol>
+            <li>Let <var>image bitmap</var> be the object on which the method
+            was invoked.
+            </li>
+            <li>Let <var>format</var> be the first argument.
+            </li>
+            <li>If the user agent cannot render <var>image bitmap</var>
+            represented in <var>format</var>, throw
+            <code>NotSupportedError</code>.
+            </li>
+            <li>Otherwise, return the length of the <a>pixel layout</a> for
+            <var>image bitmap</var> represented in <var>format</var> <a>image
+            format</a>.
+            </li>
+          </ol>
+          <p>
+            The <code><dfn>mapDataInto</dfn>(format, buffer, offset,
+            length)</code> method must run the following steps:
+          </p>
+          <ol>
+            <li>Let <var>promise</var> be a new promise.
+            </li>
+            <li>Run these substeps <a>in parallel</a>:
+              <ol>
+                <li>Let <var>image bitmap</var> be the object on which the
+                method was invoked.
+                </li>
+                <li>Let <var>format</var>, <var>buffer</var>,
+                <var>offset</var>, and <var>length</var> be the similarly named
+                method arguments.
+                </li>
+                <li>If the user agent cannot render <var>image bitmap</var>
+                represented in <var>format</var>, reject <var>promise</var>
+                with <code>NotSupportedError</code> and terminate these steps.
+                </li>
+                <li>Make a copy of the underlying image data of <var>image
+                bitmap</var> in the given format <var>format</var> into
+                <a>BufferSource</a> <var>buffer</var> at offset
+                <var>offset</var>, filling at most <var>length</var> bytes.
+                </li>
+                <li>Let <var>pixel layout</var> be a new
+                <a>ImageFormatPixelLayout</a> object that represents the image
+                data in the previous step.
+                </li>
+                <li>Resolve <var>promise</var> with <a>pixel layout</a>.
+                </li>
+              </ol>
+            </li>
+            <li>Return <var>promise</var>.
+            </li>
+          </ol>
+        </div>
       </section>
       <section id='imagebitmapfactories-interface-extensions'>
         <h2>

--- a/index.html
+++ b/index.html
@@ -1345,9 +1345,9 @@
           [data]  DDDDDDDDDDDDDDDDDDDDDDDDDDDDD...                        D
           [data]  ......
         </pre>
-        <section id='imageformatpixellayout-interface'>
+        <section id='channelpixellayout-interface'>
           <h2>
-            <code>ImageFormatPixelLayout</code> interface
+            <code>ChannelPixelLayout</code> interface
           </h2>
           <p>
             Each <a>channel</a> is represented by an <a>ChannelPixelLayout</a>
@@ -1394,9 +1394,9 @@
             </p>
           </div>
         </section>
-        <section id='channelpixellayout-interface'>
+        <section id='imageformatpixellayout-interface'>
           <h2>
-            <code>ChannelPixelLayout</code> interface
+            <code>ImageFormatPixelLayout</code> interface
           </h2>
           <pre class="idl">
             [Exposed=(Window,Worker)]
@@ -1544,9 +1544,6 @@
             image data, which describes how the data is arranged in
             <var>buffer</var> using <var>format</var>.
             </li>
-            <!-- TODO: do we want to special-case sx, sy handling if undefined? -->
-            <!-- sx - The x-coordinate of the starting point of the cropping rectangle. -->
-            <!-- sy - The y-coordinate of the starting point of the cropping rectangle. -->
             <li>If either the <em>sw</em> or <em>sh</em> arguments are
             specified but zero, return <var>promise</var> rejected with an
             <code>IndexSizeError</code> and terminate these steps.

--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
     </section>
     <section>
       <h2>
-        Extensions
+        Worker extensions
       </h2>
       <section>
         <h2>
@@ -554,6 +554,11 @@
           </p>
         </div>
       </section>
+    </section>
+    <section>
+      <h2>
+        MediaStreamTrack extensions
+      </h2>
       <section>
         <h2>
           <code>MediaStreamTrack</code> interface

--- a/index.html
+++ b/index.html
@@ -816,7 +816,7 @@
                 "DEPTH"
             };
           </pre>
-          <table class="simple">
+          <table class="simple" dfn-for="ImageFormat">
             <tr>
               <th>
                 ImageFormat
@@ -1077,7 +1077,7 @@
                 "float64"
             };
           </pre>
-          <table class="simple">
+          <table class="simple" dfn-for="DataType">
             <tr>
               <th>
                 DataType
@@ -1088,7 +1088,7 @@
             </tr>
             <tr>
               <td>
-                <code><a>uint8</a></code>
+                <code><dfn>uint8</dfn></code>
               </td>
               <td>
                 8-bit unsigned integer.
@@ -1096,7 +1096,7 @@
             </tr>
             <tr>
               <td>
-                <code><a>int8</a></code>
+                <code><dfn>int8</dfn></code>
               </td>
               <td>
                 8-bit integer.
@@ -1104,7 +1104,7 @@
             </tr>
             <tr>
               <td>
-                <code><a>uint16</a></code>
+                <code><dfn>uint16</dfn></code>
               </td>
               <td>
                 16-bit unsigned integer.
@@ -1112,7 +1112,7 @@
             </tr>
             <tr>
               <td>
-                <code><a>int16</a></code>
+                <code><dfn>int16</dfn></code>
               </td>
               <td>
                 16-bit integer.
@@ -1120,7 +1120,7 @@
             </tr>
             <tr>
               <td>
-                <code><a>uint32</a></code>
+                <code><dfn>uint32</dfn></code>
               </td>
               <td>
                 32-bit unsigned integer.
@@ -1128,7 +1128,7 @@
             </tr>
             <tr>
               <td>
-                <code><a>int32</a></code>
+                <code><dfn>int32</dfn></code>
               </td>
               <td>
                 32-bit integer.
@@ -1136,7 +1136,7 @@
             </tr>
             <tr>
               <td>
-                <code><a>float32</a></code>
+                <code><dfn>float32</dfn></code>
               </td>
               <td>
                 32-bit IEEE floating point number.
@@ -1144,7 +1144,7 @@
             </tr>
             <tr>
               <td>
-                <code><a>float64</a></code>
+                <code><dfn>float64</dfn></code>
               </td>
               <td>
                 64-bit IEEE floating point number.

--- a/index.html
+++ b/index.html
@@ -716,7 +716,7 @@
         <li>If developers use WebGL, then WebGL needs to be extended so that
         developers can pass an <a>ImageBitmap</a> into the WebGL context and
         the browser will handle how to upload the raw image data into the GPU
-        memory. Possiblely, the data is already in the GPU memory so that the
+        memory. Possibly, the data is already in the GPU memory so that the
         operation could be very efficient.
         </li>
       </ol>
@@ -733,54 +733,70 @@
       </p>
       <section id='imageformat'>
         <h2>
-          ImageFormat
+          Image format
         </h2>
         <p>
           An image or a video frame is conceptually a two-dimentional array of
-          data and each element in the array is called a <dfn>pixel</dfn>.
-          However, the pixels are usually stored in a one-dimentional array and
-          could be arranged in a variety of <a>ImageFormat</a>s. Developers
-          need to know how the pixels are formatted so that they are able to
-          process it. An <a>ImageFormat</a> describes how pixels in an image
-          are arranged and all pixels in one single image are arranged in the
-          same way. A single pixel has at least one, but usually multiple
-          <dfn>pixel value</dfn>s. The range of a pixel value varies, which
-          means different <a>ImageFormat</a>s use different <dfn>data
-          type</dfn>s to store a single pixel value. The most frequently used
-          data type is 8-bit unsigned interger whose range is from 0 to 255,
-          others could be 16-bit interger or 32-bit folating points and so
-          forth. The number of pixle values of a single pixel is called the
-          number of <dfn>channel</dfn>s of the <a>ImageFormat</a>. Multiple
-          pixel valuse of a pixel are used together to describe the captured
-          property which could be color or depth information. For example, if
-          the data is a color image in RGB color space, then it is a
-          three-channel <a>ImageFormat</a> and a pixel is described by R, G and
-          B three pixel values with range from 0 to 255. Another example, if
-          the data is a gray image, then it is a single-channel
-          <a>ImageFormat</a> with 8-bit unsigned interger data type and the
-          pixel value describes the gray scale. For depth data, it is a single
-          channel <a>ImageFormat</a> too, but the data type is 16-bit unsigned
-          interger and the pixel value is the depth level. For those
-          <a>ImageFormat</a>s whose pixels contain multiple pixel values, the
-          pixel values might be arranged in a planar way or interleaving way:
+          data and each element in the array is called a <dfn>pixel</dfn>. The
+          <a data-lt="pixel">pixels</a> are usually stored in a one-dimensional
+          array and could be arranged in a variety of <a data-lt=
+          "image format">image formats</a>. Developers need to know how the
+          <a data-lt="pixel">pixels</a> are formatted so that they are able to
+          process them.
+        </p>
+        <p>
+          The <a>image format</a> describes how pixels in an image are
+          arranged. A single pixel has at least one, but usually multiple
+          <dfn data-lt="pixel value">pixel values</dfn>. The range of a
+          <a>pixel value</a> varies, which means different <a data-lt=
+          "image format">image formats</a> use different <a data-lt=
+          "data type">data types</a> to store a single <a>pixel value</a>.
+        </p>
+        <p>
+          The most frequently used <a>data type</a> is 8-bit unsigned integer
+          whose range is from 0 to 255, others could be 16-bit integer or
+          32-bit floating points and so forth. The number of <a data-lt=
+          "pixel value">pixel values</a> of a single <a>pixel</a> is called the
+          <dfn data-lt="number of channel">number of channels</dfn> of the
+          <a>image format</a>. Multiple <a data-lt="pixel value">pixel
+          values</a> of a <a>pixel</a> are used together to describe the
+          captured property which could be color or depth information. For
+          example, if the data is a color image in RGB color space, then it is
+          a three-channel <a>image format</a> and a <a>pixel</a> is described
+          by R, G and B three pixel values with range from 0 to 255. As another
+          example, if the data is a gray image, then it is a single-channel
+          <a>image format</a> with 8-bit unsigned integer <a>data type</a> and
+          the <a>pixel value</a> describes the gray scale. For depth data, it
+          is a single channel <a>image format</a> too, but the <a>data type</a>
+          is 16-bit unsigned integer and the <a>pixel value</a> is the depth
+          level.
+        </p>
+        <p>
+          For those <a data-lt="image format">image formats</a> whose
+          <a data-lt="pixel">pixels</a> contain multiple <a data-lt=
+          "pixel value">pixel values</a>, the <a data-lt="pixel value">pixel
+          values</a> might be arranged in one of the following ways:
         </p>
         <ol>
           <li>
-            <dfn>Planar pixel layout</dfn>: each channel has its pixel values
-            stored consecutively in separated buffers (a.k.a. planes) and then
-            all channel buffers are stored consecutively in memory. (Ex:
+            <dfn>Planar pixel layout</dfn>: each <a>channel</a> has its
+            <a data-lt="pixel value">pixel values</a> stored consecutively in
+            separated buffers (a.k.a. planes) and then all channel buffers are
+            stored consecutively in memory. (Ex:
             RRRRRR......GGGGGG......BBBBBB......)
           </li>
           <li>
-            <dfn>Interleaving pixel layout</dfn>: each pixel has its pixel
-            values from all channels stored together and interleaves all
-            channels. (Ex: RGBRGBRGBRGBRGB......)
+            <dfn>Interleaving pixel layout</dfn>: each <a>pixel</a> has its
+            <a data-lt="pixel value">pixel values</a> from all <a data-lt=
+            "channel">channels</a> stored together and interleaves all
+            <a data-lt="channel">channels</a>. (Ex: RGBRGBRGBRGBRGB......)
           </li>
         </ol>
         <div class="note">
           <p>
-            <a>ImageFormat</a>s belong to the same color space might have
-            different pixel layouts.
+            <a data-lt="image format">Image formats</a> that belong to the same
+            color space might have different <a data-lt="pixel layout">pixel
+            layouts</a>.
           </p>
         </div>
         <section id='imageformat-enumaration'>
@@ -788,11 +804,12 @@
             <code>ImageFormat</code> enumeration
           </h2>
           <p>
-            An enumeration <a>ImageFormat</a> defines a list of image formats
-            which are supported by the browser and exposed to users. The extend
-            APIs in this specification use this enumeration to negotiate the
-            format while accessing the underlying data of <a>ImageBitmap</a>
-            and creating a new <a>ImageBitmap</a>.
+            The <a>ImageFormat</a> enumeration is used to select the <dfn>image
+            format</dfn> for the <a>ImageFormatPixelLayout</a>. The
+            <a>ImageBitmap</a> extensions defined in this specification use
+            this enumeration to negotiate the <a>image format</a> while
+            accessing the underlying data of <a>ImageBitmap</a> and creating a
+            new <a>ImageBitmap</a>.
           </p>
           <div class="note">
             <p>
@@ -1062,8 +1079,8 @@
             <code>DataType</code> enumeration
           </h2>
           <p>
-            An enumeration <a>DataType</a> defines a list of data types that is
-            used to store a single <a>pixel value</a>.
+            The <a>DataType</a> enumeration is used to select the <dfn>channel
+            data type</dfn> that is used to store a single <a>pixel value</a>.
           </p>
           <pre class="idl">
             enum DataType {
@@ -1155,50 +1172,56 @@
       </section>
       <section id='pixellayout'>
         <h2>
-          PixelLayout
+          Pixel layout
         </h2>
         <p>
           Two interfaces, <a>ImageFormatPixelLayout</a> and
-          <a>ChannelPixelLayout</a>, help together to generalize the variety of
-          pixel layouts among image formats.
+          <a>ChannelPixelLayout</a>, together generalize the variety of
+          <a data-lt="pixel layout">pixel layouts</a> among <a data-lt=
+          "image format">image formats</a>.
         </p>
         <p>
-          The <a>ImageFormatPixelLayout</a> represents the pixel layout of a
-          certain image format and since a image format is composed by at least
-          one <a>channel</a> so an <a>ImageFormatPixelLayout</a> object
-          contains at least one <a>ChannelPixelLayout</a> object.
+          The <a>ImageFormatPixelLayout</a> represents the <dfn>pixel
+          layout</dfn> of a certain <a data-lt="image format">image format</a>.
+          Since an <a>image format</a> is composed of at least one
+          <dfn>channel</dfn>, an <a>ImageFormatPixelLayout</a> object contains
+          at least one <a>ChannelPixelLayout</a> object. 
+          <!-- TODO: more elaborate description of a channel needed -->
         </p>
         <p>
           Although an image or a video frame is a two-dimensional structure,
-          its data is usually stored in an one-dimensional array in the
-          raw-major way and the <a>ChannelPixelLayout</a> uses the following
-          properties to describe how pixel values are arranged in the one
-          dimentional array buffer.
+          its data is usually stored in a one-dimensional array in the
+          row-major way and each <a>channel</a> describes how <a data-lt=
+          "pixel value">pixel values</a> are arranged in the one dimensional
+          array buffer.
         </p>
-        <ol>
-          <li>
-            <strong>offset</strong>: where is each <a>channel</a>'s data starts
-            from. (Relative to the beginning of the video data one-dimension
-            array.)
-          </li>
-          <li>
-            <strong>width</strong> and <strong>height</strong>: how much
-            samples are in each channel.
-          </li>
-          <li>
-            <strong>data type</strong>: the data type used to store one single
-            <a>pixel value</a>.
-          </li>
-          <li>
-            <strong>stride</strong>: the total bytes of each raw plus the
-            padding bytes of each row.
-          </li>
-          <li>
-            <strong>skip</strong>: this is used to describe <a>interleaving
-            pixel layout</a>. (For <a>planar pixel layout</a>, this property
-            will be zero.)
-          </li>
-        </ol>
+        <p>
+          A <a>channel</a> has an associated <dfn>offset</dfn> that denotes the
+          beginning position of the <a>channel</a>'s data relative to the given
+          <a>BufferSource</a> parameter of the
+          <code><a>mapDataInto</a>()</code> method.
+        </p>
+        <p>
+          A <a>channel</a> has an associated <dfn>width</dfn> and
+          <dfn>height</dfn> that denote the width and height of the
+          <a>channel</a> respectively. Each <a>channel</a> in an <a>image
+          format</a> may have different height and width.
+        </p>
+        <p>
+          A <a>channel</a> has an associated <dfn>data type</dfn> used to store
+          one single <a>pixel value</a>.
+        </p>
+        <p>
+          A <a>channel</a> has an associated <dfn>stride</dfn> that is the
+          number of bytes between the beginning two consecutive rows in memory.
+          (The total bytes of each row plus the padding bytes of each raw.)
+        </p>
+        <p>
+          A <a>channel</a> has an associated <dfn>skip</dfn> value. The value
+          is zero for the <a>planar pixel layout</a>, and a positive integer
+          for the <a>interleaving pixel layout</a>. (Describes how many bytes
+          there are between two adjacent pixel values in this channel.)
+        </p>
         <pre class='example highlight'>
           Example1: RGBA image, width = 620, height = 480, stride = 2560
 
@@ -1294,92 +1317,67 @@
           <h2>
             <code>ImageFormatPixelLayout</code> interface
           </h2>
-          <dl class="idl" title=
-          "[Exposed=(Window,Worker)] interface ChannelPixelLayout">
-            <dt>
-              readonly attribute unsigned long offset
-            </dt>
-            <dd>
-              <p>
-                The beginning position of this <a>channel</a>'s data (relative
-                to the given <a>BufferSource</a> parameter of the mapDataInto()
-                method.)
-              </p>
-            </dd>
-            <dt>
-              readonly attribute unsigned long width
-            </dt>
-            <dd>
-              <p>
-                The width of this channel. <a>Channel</a>s in an image format
-                may have different width.
-              </p>
-            </dd>
-            <dt>
-              readonly attribute unsigned long height
-            </dt>
-            <dd>
-              <p>
-                The height of this channel. <a>Channel</a>s in an image format
-                may have different height.
-              </p>
-            </dd>
-            <dt>
-              readonly attribute DataType dataType
-            </dt>
-            <dd>
-              <p>
-                The data type used to store one single <a>pixel value</a>.
-              </p>
-            </dd>
-            <dt>
-              readonly attribute unsigned long stride
-            </dt>
-            <dd>
-              <p>
-                The stride of this channel.
-              </p>The stride is the number of bytes between the beging two
-              consecutive raws in memory.
-              <p>
-                The total bytes of each raw plus the padding bytes of each raw.
-              </p>
-            </dd>
-            <dt>
-              readonly attribute unsigned long skip
-            </dt>
-            <dd>
-              <p>
-                This is used to describe how much bytes between two adjacent
-                <a>pixel value</a>s in this channel.
-              </p>
-              <p>
-                Possible values:
-              </p>
-              <ul>
-                <li>zero: for <a>planar pixel layout</a>.
-                </li>
-                <li>a positive integer: for <a>interleaving pixel layout</a>.
-                </li>
-              </ul>
-            </dd>
-          </dl>
+          <p>
+            Each <a>channel</a> is represented by an <a>ChannelPixelLayout</a>
+            object.
+          </p>
+          <pre class="idl">
+            [Exposed=(Window,Worker)]
+            interface ChannelPixelLayout {
+                readonly    attribute unsigned long offset;
+                readonly    attribute unsigned long width;
+                readonly    attribute unsigned long height;
+                readonly    attribute DataType      dataType;
+                readonly    attribute unsigned long stride;
+                readonly    attribute unsigned long skip;
+            };
+          </pre>
+          <div dfn-for="ChannelPixelLayout">
+            <p>
+              The <dfn>offset</dfn> attribute represents the <a>channel</a>'s
+              <a>offset</a>.
+            </p>
+            <p>
+              The <dfn>width</dfn> attribute represents the <a>width</a> of the
+              <a>channel</a>. (Channels in an image format may have different
+              width.)
+            </p>
+            <p>
+              The <dfn>height</dfn> attribute represents the <a>height</a> of
+              the <a>channel</a>. (Channels in an image format may have
+              different height.)
+            </p>
+            <p>
+              The <dfn>dataType</dfn> attribute must return the <a>data
+              type</a> of the <a>channel</a>, one of the <a data-lt=
+              "channel data type">channel data types</a>.
+            </p>
+            <p>
+              The <dfn>stride</dfn> attribute represents the <a>stride</a> of
+              the <a>channel</a>.
+            </p>
+            <p>
+              The <dfn>skip</dfn> attribute represents the <a>skip</a> value
+              for the <a>channel</a>.
+            </p>
+          </div>
         </section>
         <section id='channelpixellayout-interface'>
           <h2>
             <code>ChannelPixelLayout</code> interface
           </h2>
-          <dl class="idl" title=
-          "[Exposed=(Window,Worker)] interface ImageFormatPixelLayout">
-            <dt>
-              readonly attribute sequence&lt;ChannelPixelLayout&gt; channels
-            </dt>
-            <dd>
-              <p>
-                Channel information of this image format. Each image format has
-                at least one <a>channel</a>.
-              </p>
-            </dd>
-          </dl>
+          <pre class="idl">
+            [Exposed=(Window,Worker)]
+            interface ImageFormatPixelLayout {
+                readonly    attribute ChannelPixelLayout[] channels;
+            };
+          </pre>
+          <p dfn-for="ImageFormatPixelLayout">
+            The <dfn>channels</dfn> attribute must return a read only array of
+            <a>ChannelPixelLayout</a> objects. The returned array represents
+            <a data-lt="channel">channels</a> of the <a>image format</a>. Each
+            <a>image format</a> has at least one <a>channel</a>.
+          </p>
         </section>
       </section>
       <section id='imagebitmap-interface-extensions'>


### PR DESCRIPTION
This is a work-in-progress PR to convert the ImageBitmap extensions to use Contiguous IDL.

Status:
- [x] `ImageFormat` and `DataType` enums
- [x] `PixelLayout`
- [x] `ImageBitmap` interface
- [x] `ImageBitmapFactories` interface

Fixes https://github.com/w3c/mediacapture-worker/pull/19
