### PR TITLE
Use the correct ReSpec license boilerplate

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
           // Team Contact.
           wgPatentURI:  ["", ""],
           // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
+          license: "w3c-software-doc"
       };
     </script>
   </head>


### PR DESCRIPTION
ReSpec [recently added](http://www.w3.org/mid/etPan.5609bf67.b597a3c.fbf8@Zero-privacy.local) support for the [permissive document license](http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document) boilerplate. This PR updates the spec accordingly.

We already state in the Status of This Document that we use the W3C [Software and Document license](http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document). This is to align the spec boilerplate with that section.
