### PR TITLE
Fix #47 - make HSV and Lab using 32bit floting point.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1020,7 +1020,7 @@
                 interleaving hsv-channels
               </td>
               <td>
-                8-bit unsigned integer
+                32-bit IEEE floating point number
               </td>
             </tr>
             <tr>
@@ -1037,7 +1037,7 @@
                 interleaving lab-channels
               </td>
               <td>
-                8-bit unsigned integer
+                32-bit IEEE floating point number
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
This PR makes the HSV and Lab color space be defined in the 32-bit floating point domain.
